### PR TITLE
Optimized %%

### DIFF
--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1023,7 +1023,7 @@ class exports.Binary extends Node
   
   compileMod: (o) ->
     ref = o.scope.temporary!
-    code = "((#{@first.compile o}) % (#ref = #{@second.compile o}) + #ref) % #ref"
+    code = "((#{@first.compile o}) + (#ref = #{@second.compile o})) % #ref"
     o.scope.free ref
     code
 


### PR DESCRIPTION
I like the %% operator! 

Very 'mathy' and I've had reason to use it before, especially when accessing arrays: 
`ra[num % ra.length]` works unless num is negative. `ra[num %% ra.length]` works even better.

Can be mathematically proven that it can be optimized to `(x + y) % y` instead of `(x % y + y) % y`

Ran it against your test suite and it still builds, compiles and returns correct results.
