### PR TITLE
Fixes first half of issue #12 

### DIFF
--- a/src/command.ls
+++ b/src/command.ls
@@ -223,7 +223,7 @@ switch
       if o.compile
         say LiveScript.compile code, {o.bare}
       else
-        _  = vm.runInThisContext LiveScript.compile(code, {\eval o.bare}), \repl
+        _  = vm.runInThisContext LiveScript.compile(code, {\eval, +bare}), \repl
         _ !? global <<< {_}
         pp  _
         say _ if typeof _ is \function


### PR DESCRIPTION
Variables disappear in interactive mode (issue #12)

% bin/livescript -i
livescript> answer = 42
42
livescript> answer
ReferenceError: answer is not defined

https://github.com/gkz/LiveScript/issues/12
