### PR TITLE
More loosely restrict node.js versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     }
   ],
   "engines": {
-    "node": ">= 0.6.15"
+    "node": ">= 0.6.0 <= 0.9.0"
   },
   "directories": {
     "lib": "./lib"


### PR DESCRIPTION
Is there any reason it requires only 0.6.15+?

I have 0.6.14 and sadly I can't compile the new node version because of mountain lion bugs.

<= 0.9.0 restriction is because node.js can release some incompatible to livescript stuff in the future and break `npm install LiveScript`. This happened to many packages already.
