### PR TITLE
Tracks mangled identifiers for inconsistencies

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -82,6 +82,15 @@ exports.tokenize = function(code, o){
   return this.tokens;
 };
 exports.dent = 0;
+exports.identifiers = {};
+exports.hasOwn = Object.prototype.hasOwnProperty;
+exports.checkConsistency = function(camel, id){
+  if (this.hasOwn.call(this.identifiers, camel) && this.identifiers[camel] !== id) {
+    throw new ReferenceError("Inconsistent use of " + camel + " as " + id);
+  } else {
+    return this.identifiers[camel] = id;
+  }
+};
 exports.doID = function(code, index){
   var match, input, id, last, tag, __ref;
   input = (match = (ID.lastIndex = index, ID).exec(code))[0];
@@ -91,6 +100,9 @@ exports.doID = function(code, index){
   id = match[1].replace(/-+([a-zA-Z0-9$_])/g, function(it){
     return it[1].toUpperCase();
   });
+  if (/-/.test(match[1])) {
+    this.checkConsistency(id, match[1]);
+  }
   if (NONASCII.test(id)) {
     try {
       Function("var " + id);

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -82,6 +82,19 @@ exports import
   # The current indentation level.
   dent: 0
 
+  # Map of all Identifiers
+  identifiers: {}
+
+  has-own: Object.prototype.has-own-property,
+
+  # Checks for consistent use of Identifiers with dashes
+  # Raises an error if two different identifiers mangle into the same camelCased id
+  check-consistency: (camel, id) ->
+    if @has-own.call(@identifiers, camel) and @identifiers[camel] isnt id
+      then throw new ReferenceError "Inconsistent use of #{camel} as #{id}"
+      else @identifiers[camel] = id
+
+
   #### Tokenizers
 
   # Matches an identifying literal: variables, keywords, accessors, etc.
@@ -89,6 +102,7 @@ exports import
     [input] = match = (ID <<< lastIndex: index)exec code
     return 0 unless input
     id = match.1.replace /-+([a-zA-Z0-9$_])/g, -> it.1.toUpperCase!
+    @check-consistency id, match.1 if /-/.test match.1
     if NONASCII.test id
       try Function "var #id" catch @carp "invalid identifier \"#id\""
     {last} = this

--- a/test/assignment.ls
+++ b/test/assignment.ls
@@ -365,11 +365,6 @@ eq 1  a-1
 eq 1  4-b
 eq 99 a-b
 
-encodeURL = 9
-eq 9 encode-URL
-eq 9 encode-uRL
-eq 9 encode-u-r-l
-
 obj =
   ha-ha: 2
 

--- a/test/compilation.ls
+++ b/test/compilation.ls
@@ -175,3 +175,5 @@ null
 
 # Dash seperated identifiers
 throws "Parse error on line 1: Unexpected 'ID'" -> LiveScript.compile 'a--b = 1'
+
+throws "Inconsistent use of encodeURL as encode-u-r-l" -> LiveScript.compile 'encode-URL is encode-u-r-l'


### PR DESCRIPTION
Related to #17 [this comment](https://github.com/gkz/LiveScript/issues/17#issuecomment-6489808)

This keeps track of IDs in the lexer in an Object and if two dashed IDs mangle into the same camelCased ID then a ReferenceError is thrown.
- I removed the encodeURL test from `assignment.ls` since it was failing due to the new feature.
- I added that test to `compilation.ls` to make sure the error was being thrown.

tests:

```
bin/slake test
passed 1337 tests in 0.41 seconds
```
