### PR TITLE
Don't clobber the global scope in command.ls

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -340,7 +340,6 @@ function repl(){
     }
     server = (ref$ = clone$(require('repl').REPLServer.prototype), ref$.context = replCtx, ref$.commands = [], ref$.useGlobal = false, ref$.useColors = process.env.NODE_DISABLE_COLORS, ref$.eval = function(code, ctx, arg$, cb){
       var res, e, err;
-      console.log(ctx);
       try {
         res = vm.runInNewContext(code, ctx, 'repl');
       } catch (e$) {

--- a/src/command.ls
+++ b/src/command.ls
@@ -229,7 +229,6 @@ switch
       context: repl-ctx, commands: [], useGlobal: false
       useColors: process.env.NODE_DISABLE_COLORS
       eval: !(code,ctx,, cb) ->
-        console.log ctx
         try res = vm.runInNewContext code, ctx, \repl catch then err = e
         cb err, res
     rl.completer = server~complete


### PR DESCRIPTION
command.ls exports a load of things to `global`. This causes differing behaviour when running LiveScript directly to running the compiled JavaScript: if you use `fs`, `path` &c. without importing the module, it works fine in LiveScript, but then complains once compiled. This has come back to bite me a couple of times at work. This patch still lets these modules, as well as p{1,3}, say, &c., be used in the REPL.

p.s. currently this fucks up tab completion (it prints the entire util.inspect for things in the context), any ideas?
