### PR TITLE
fix #210

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -3901,6 +3901,7 @@ exports.Require = Require = (function(superclass){
     };
     processItem = function(item){
       var ref$, asg, value, main;
+      chain = null;
       ref$ = (function(){
         var ref$;
         switch (false) {

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -2391,6 +2391,7 @@ class exports.Require extends Node
         get-value item.head
       | otherwise               => item
     process-item = (item) ->
+      chain := null
       [asg, value] = switch
       | item instanceof Prop    => [get-value item.key; item.val]
       | item instanceof Chain   =>


### PR DESCRIPTION
Only need to ensure `chain` is null before starting processing item
#210
