### PR TITLE
require 'prelude-ls' when loading the CLI. Makes -d work when LiveScript is installed globally.

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -1,9 +1,10 @@
-var argv, LiveScript, path, fs, util, o, $args, that, filename, join$ = [].join;
+var argv, LiveScript, path, fs, util, preludeLs, o, $args, that, filename, join$ = [].join;
 argv = process.argv;
 LiveScript = require('./livescript');
 path = require('path');
 fs = require('fs');
 util = require('util');
+preludeLs = require('prelude-ls');
 function say(it){
   process.stdout.write(it + '\n');
 }
@@ -318,7 +319,7 @@ function repl(){
     module.paths = module.constructor._nodeModulePaths(module.filename = process.cwd() + '/repl');
     vm = require('vm');
     if (o.prelude) {
-      import$(global, require('prelude-ls'));
+      import$(global, preludeLs);
     }
     replCtx = {};
     import$(replCtx, global);

--- a/src/command.ls
+++ b/src/command.ls
@@ -7,6 +7,7 @@ require! {
   path
   fs
   util
+  \prelude-ls
 }
 
 !function say => process.stdout.write it + \\n
@@ -218,7 +219,7 @@ switch
     module.paths = module.constructor._nodeModulePaths \
       module.filename = process.cwd! + \/repl
     vm = require \vm
-    global <<< require \prelude-ls if o.prelude
+    global <<< preludeLs if o.prelude
     repl-ctx = {}
     repl-ctx <<< global
     repl-ctx <<< {module, exports, require}


### PR DESCRIPTION
Using Node.js v0.10.5, running a globally installed LiveScript using `lsc -id` (interactive + require prelude) throws this error.

```
module.js:340
    throw err;
          ^
Error: Cannot find module 'prelude-ls'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at repl (/Users/dttvb/github/LiveScript/lib/command.js:321:23)
    at Object.<anonymous> (/Users/dttvb/github/LiveScript/lib/command.js:89:5)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
```

I make 'command.ls' require 'prelude-ls' at the top instead of on demand, I don't know why, but that fixed it. Running `lsc -id` now works:

```
▹ lsc -id
livescript> id
[Function]
function (x){
  return x;
}
livescript> 
```
