### PR TITLE
Bumping Node.js version in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10


### PR DESCRIPTION
Looked like this might be the cause of recent build failures
