### PR TITLE
Make backslash gobble line comments

### DIFF
--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -1266,7 +1266,10 @@ SPACE     = /[^\n\S]*(?:#.*)?/g
 MULTIDENT = /(?:\s*#.*)*(?:\n([^\n\S]*))*/g
 SIMPLESTR = /'[^\\']*(?:\\[\s\S][^\\']*)*'|/g
 JSTOKEN   = /``[^\\`]*(?:\\[\s\S][^\\`]*)*``|/g
-BSTOKEN   = // \\ (?: (\S[^\s,;)}\]]*) | \s* ) //g
+BSTOKEN   = // \\ (?:
+  (\S[^\s,;)}\]]*)          # word literal
+| (?: #{SPACE.source}\n? )* # whitespace (including line comments)
+)//g
 
 NUMBER = //
   0x[\dA-Fa-f][\dA-Fa-f_]*                # hex

--- a/test/comment.ls
+++ b/test/comment.ls
@@ -173,6 +173,11 @@ eq true, do
 
 eq 0, [0]/* inline block comment */[0]
 
+# Ensure that backslash gobbles line comments as well as regular whitespace
+# [#550](https://github.com/gkz/LiveScript/issues/550)
+({a, b, \
+ #comment
+ c})->
 
 /*
 Trailing block comment works.


### PR DESCRIPTION
...in addition to regular whitespace.
Fixes gkz/LiveScript#550
