### PR TITLE
Add Gitter chat badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ is a language which compiles to JavaScript. It has a straightforward mapping to 
 
 Check out **[livescript.net](http://livescript.net)** for more information, examples, usage, and a language reference.
 
-### Build Status
 [![Build Status](https://travis-ci.org/gkz/LiveScript.png?branch=master)](https://travis-ci.org/gkz/LiveScript)
 
 ### Install

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ is a language which compiles to JavaScript. It has a straightforward mapping to 
 Check out **[livescript.net](http://livescript.net)** for more information, examples, usage, and a language reference.
 
 [![Build Status](https://travis-ci.org/gkz/LiveScript.png?branch=master)](https://travis-ci.org/gkz/LiveScript)
+[![Gitter chat](https://badges.gitter.im/gitterHQ/gitter.png)](https://gitter.im/gkz/LiveScript)
 
 ### Install
 Have Node.js installed. `sudo npm install -g LiveScript`


### PR DESCRIPTION
The [LiveScript Gitter chat](https://gitter.im/gkz/LiveScript) is mainly inactive, but I think it could be great if we started using it. Since it allows github login, it would make it much easier to find other LiveScripters, and could reduce the multitude of [gh issues](https://github.com/gkz/LiveScript/issues) that are about really small problems.

I'm aware of [/r/livescript](http://www.reddit.com/r/livescript/) and [the Google Group](https://groups.google.com/forum/#!forum/livescript), but they're better oriented for large topics, don't work with a github account, and aren't "officially" endorsed either as far as I can tell.

What do you think?