### PR TITLE
Betterify editor documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <li><a href="#installation">Installation</a></li>
         <li><a href="#usage">Usage</a></li>
         <li><a href="#community">Community</a></li>
-        <li><a href="#editor-support">Editor Plugins</a></li>
+        <li><a href="#editor-support">Text Editor/IDE Plugins</a></li>
         <li><a href="#prelude-ls">Standard Library</a></li>
         <li class="divider">
         <li><a href="#introduction">Introduction</a></li>
@@ -412,7 +412,7 @@ $('h1').on('click', function(){
     </div>
     <div id="editor-support" class="section">
       <a name="editor-support"></a>
-      <h2>Editor Plugins</h2>
+      <h2>Text Editor/IDE Plugins</h2>
       <ul>
         <li>Vim users, check out <a href="https://github.com/gkz/vim-ls">vim-ls</a>.</li>
         <li>TextMate, Chocolat, and Sublime Text bundle for LiveScript: <a href="https://github.com/paulmillr/LiveScript.tmbundle">LiveScript.tmbundle</a>.</li>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
         <li><a href="#installation">Installation</a></li>
         <li><a href="#usage">Usage</a></li>
         <li><a href="#community">Community</a></li>
-        <li><a href="#editor-support">Text Editor Support</a></li>
+        <li><a href="#editor-support">Editor Plugins</a></li>
         <li><a href="#prelude-ls">Standard Library</a></li>
         <li class="divider">
         <li><a href="#introduction">Introduction</a></li>
@@ -412,13 +412,13 @@ $('h1').on('click', function(){
     </div>
     <div id="editor-support" class="section">
       <a name="editor-support"></a>
-      <h2>Text Editor Support</h2>
+      <h2>Editor Plugins</h2>
       <ul>
-        <li>Vim users check out <a href="https://github.com/gkz/vim-ls">vim-ls</a>.
-        <li>TextMate, Chocolat, and Sublime Text bundle for LiveScript: <a href="https://github.com/paulmillr/LiveScript.tmbundle">LiveScript.tmbundle</a>.
-        <li>Emacs basic LiveScript support: <a href="https://github.com/tensai-cirno/livescript-mode">livescript-mode</a>
+        <li>Vim users, check out <a href="https://github.com/gkz/vim-ls">vim-ls</a>.</li>
+        <li>TextMate, Chocolat, and Sublime Text bundle for LiveScript: <a href="https://github.com/paulmillr/LiveScript.tmbundle">LiveScript.tmbundle</a>.</li>
+        <li>Emacs basic LiveScript support: <a href="https://github.com/tensai-cirno/livescript-mode">livescript-mode</a>.</li>
+        <li>And more on the <a href="https://github.com/gkz/LiveScript/wiki/Projects-supporting-LiveScript">wiki page</a>. Add yours to the growing list!</li>
       </ul>
-      <p>Add yours to the <a href="https://github.com/gkz/LiveScript/wiki/Projects-supporting-LiveScript">wiki page</a>.
     </div>
     <div id="prelude-ls" class="section">
       <a name="prelude-ls">


### PR DESCRIPTION
"Text editor support" can imply native support within text editors themselves, as in like Atom's support for JavaScript and CoffeeScript and Eclipse's support for Java. I thought this would better convey the meaning.