### PR TITLE
fix: Compiler full screen for 1550px doesn't work.

### DIFF
--- a/styles.less
+++ b/styles.less
@@ -228,7 +228,7 @@ h1 {
   .sidebar h1 a {
     font-size: 32px;
   }
-  .row-fluid > .span4.compiler {
+  .row-fluid > .span4.compiler:not(.fullscreen-compiler div) {
     width: 26.623931624%;
   }
   .row-fluid > .span6.content {


### PR DESCRIPTION
My macbook's resolution is 1440x900, If you resize the browser to that size, the compiler won't go full screen.