### PR TITLE
Replace deprecated customFds option in child_process.spawn (#657)

### DIFF
--- a/src/command.ls
+++ b/src/command.ls
@@ -280,4 +280,4 @@ switch
   require 'child_process' .spawn do
     process.exec-path
     node-args ++ ls-args
-    cwd: process.cwd!, custom-fds: [0 1 2]
+    cwd: process.cwd!, stdio: 'inherit'


### PR DESCRIPTION
re #657 Replacing `customFds` with `stdio` option because of [deprecation](http://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options).