### PR TITLE
options: add alias -k for --const

### DIFF
--- a/src/options.ls
+++ b/src/options.ls
@@ -56,6 +56,7 @@ module.exports = optionator do
       type: 'Boolean'
       description: 'watch scripts for changes, and repeat'
     * option: 'const'
+      alias: 'k'
       type: 'Boolean'
       description: 'compile all variables as constants'
 


### PR DESCRIPTION
-k is mentioned as an alias for `--const` in the documentation