### PR TITLE
Few more failing object comprehension tests

### DIFF
--- a/test/loop.ls
+++ b/test/loop.ls
@@ -650,3 +650,16 @@ f = ->
   true
 o = {[k, v] for k, v of {a: 1} when f!}
 eq 1 i
+
+i = 0
+{o} = {[k, v] for k, v of {a: 1} when f!}
+eq 1 i
+
+i = 0
+g = ->
+g {[k, v] for k, v of {a: 1} when f!}
+eq 1 i
+
+i = 0
+o = {[k, v] for k, v of {a: 1} when f!}.a
+eq 1 i


### PR DESCRIPTION
gkz/LiveScript#639 still isn't fixed...here's a few more failing tests. :(

@gkz PTAL

The test simply throws at the erroneously added `.push`, which incidentally, the method's argument is what's *supposed* to be the whole statement.