### PR TITLE
Fix content and compiler width

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
         <li><a href="#changes">Changes from Coco</a></li>
       </ul>
     </div>
-    <div class="span4 compiler">
+    <div class="span3 compiler">
       <div class="compiler-box">
         <div id="compiler-close-button">&times;</div>
         <div class="github-buttons">
@@ -89,7 +89,7 @@
   </div>
   <div class="row-fluid content-row">
     <div class="span2">&nbsp;</div>
-    <div class="span6 content">
+    <div class="span7 content">
       <div id="overview" class="section">
         <a name="overview"></a>
         <h2>Overview</h2>
@@ -2310,7 +2310,7 @@ export value-a, value-b, value-c
 
 
 
-export 
+export
   a: 1
   b: -> 123
 


### PR DESCRIPTION
![2015-05-27 11 49 22](https://cloud.githubusercontent.com/assets/557961/7827804/7634bd8c-0466-11e5-93f8-39170a34dd26.png)

OSX 10.10.2 / Chrome 43.0.2357.81

I fixed compiler and content pane width because compiler pane is overlap in content pane.

Preview:

![2015-05-27 11 54 11](https://cloud.githubusercontent.com/assets/557961/7827862/2359082e-0467-11e5-902e-5de1719a621c.png)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/gkz/livescript/735)
<!-- Reviewable:end -->
