### PR TITLE
Fix to SPDX license spec

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,7 @@
   "author": "George Zahariev <z@georgezahariev.com>",
   "homepage": "http://livescript.net",
   "bugs": "https://github.com/gkz/LiveScript/issues",
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "https://raw.githubusercontent.com/gkz/LiveScript/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "engines": {
     "node": ">= 0.8.0"
   },

--- a/package.json.ls
+++ b/package.json.ls
@@ -14,9 +14,7 @@ keywords:
 author: 'George Zahariev <z@georgezahariev.com>'
 homepage: 'http://livescript.net'
 bugs: 'https://github.com/gkz/LiveScript/issues'
-licenses:
-  type: 'MIT', url: 'https://raw.githubusercontent.com/gkz/LiveScript/master/LICENSE'
-  ...
+license: 'MIT'
 
 engines:
   node: '>= 0.8.0'


### PR DESCRIPTION
`npm` [updated to use SPDX "license" metadata](https://github.com/npm/npm/releases/tag/v2.10.0). It gives you warnings if you don't use it. This PR fixes that.