### PR TITLE
make process.execPath point to node instead of lsc

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -80,7 +80,7 @@ version = LiveScript.VERSION;
     }
     o.run = !(o.compile || (o.compile = o.output));
     if (args === process.argv) {
-      process.execPath = process.argv[0] = process.argv[1];
+      process.argv[0] = process.argv[1];
       toInsert = o.stdin
         ? positional
         : o.run

--- a/src/command.ls
+++ b/src/command.ls
@@ -48,7 +48,7 @@ switch
   o.run = not o.compile ||= o.output
 
   if args is process.argv
-    process.exec-path = process.argv.0 = process.argv.1
+    process.argv.0 = process.argv.1
     to-insert = if o.stdin
       positional
     else


### PR DESCRIPTION
When running a script in lsc, process.execPath points to lsc instead of node. This leads to issues with libraries such as shelljs: https://github.com/gkz/LiveScript/issues/562 and https://github.com/shelljs/shelljs/issues/160
