### PR TITLE
fix: `yield` expression should be callable

### DIFF
--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1124,6 +1124,8 @@ class exports.Yield extends Node
 
     show: -> if @op is 'yieldfrom' then 'from' else ''
 
+    ::delegate <[ isCallable ]> -> yes
+
     compile-node: (o) ->
         code = []
 

--- a/test/generators.ls
+++ b/test/generators.ls
@@ -137,12 +137,16 @@ g5.next!
 g5.next true
 g5.next false
 
-# calling a yield
+# yield expression as argument, as callable
 is-two = -> it == 2
 f6 = ->*
     is-two yield 1
+    ok (yield 1)(2)
+    ok (2 |> yield 1)
 g6 = f6!
 eq 1 g6.next(2).value
+g6.next is-two
+g6.next is-two
 
 # in switch
 f7 = (x) ->*


### PR DESCRIPTION
Since `yield` expressions evaluate to argument passed to `next`, if a function is passed it should be callable.

Example:

```livescript
f = ->* (yield)!
g = -> console.log 'hit'
f!
  ..next!
  ..next g
```

should compile to:

```javascript
var f, g, x$;
f = function*(){
  return (yield)();
};
g = function(){
  return console.log('hit');
};
x$ = f();
x$.next();
x$.next(g);
```