### PR TITLE
Support unary operator spread over object literals

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1932,13 +1932,22 @@ exports.Unary = Unary = (function(superclass){
     }
   };
   prototype.compileSpread = function(o){
-    var it, ops, them, i$, len$, i, node, sp, j$, op, lat, ref$;
+    var it, ops, isSpread, isObj, them, i$, len$, i, node, sp, j$, op, lat, ref$;
     it = this.it;
     ops = [this];
     for (; it instanceof constructor; it = it.it) {
       ops.push(it);
     }
-    if (!((it = it.expandSlice(o).unwrap()) instanceof Arr && (them = it.items).length)) {
+    isSpread = (it = it.expandSlice(0).unwrap()) instanceof Arr || (isObj = it instanceof Obj && !function(){
+      var i$, x$, ref$, len$, ref1$;
+      for (i$ = 0, len$ = (ref$ = ops).length; i$ < len$; ++i$) {
+        x$ = ref$[i$];
+        if ((ref1$ = x$.op) !== '~' && ref1$ !== '!' && ref1$ !== 'new' && ref1$ !== 'do' && ref1$ !== 'delete' && ref1$ !== 'jsdelete' && ref1$ !== '++' && ref1$ !== '--') {
+          return true;
+        }
+      }
+    }());
+    if (!(isSpread && (them = it.items).length)) {
       return '';
     }
     for (i$ = 0, len$ = them.length; i$ < len$; ++i$) {
@@ -1946,15 +1955,30 @@ exports.Unary = Unary = (function(superclass){
       node = them[i$];
       if (sp = node instanceof Splat) {
         node = node.it;
+      } else if (isObj) {
+        node = node.val;
       }
       for (j$ = ops.length - 1; j$ >= 0; --j$) {
         op = ops[j$];
         node = constructor(op.op, node, op.post);
       }
-      them[i] = sp ? lat = Splat(node) : node;
+      if (sp) {
+        them[i] = lat = Splat(node);
+      } else if (isObj) {
+        them[i].val = node;
+      } else {
+        them[i] = node;
+      }
     }
     if (!lat && (this['void'] || !o.level)) {
-      it = (ref$ = Block(them), ref$.front = this.front, ref$['void'] = true, ref$);
+      it = (ref$ = Block(isObj ? (function(){
+        var i$, x$, ref$, len$, results$ = [];
+        for (i$ = 0, len$ = (ref$ = them).length; i$ < len$; ++i$) {
+          x$ = ref$[i$];
+          results$.push(x$.val);
+        }
+        return results$;
+      }()) : them), ref$.front = this.front, ref$['void'] = true, ref$);
     }
     return it.compile(o, LEVEL_PAREN);
   };

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1229,18 +1229,25 @@ class exports.Unary extends Node
         if o.level < LEVEL_CALL then sn(this, ...code) else sn(this, "(", ...code, ")")
 
     # `^delete o[p, ...q]` => `[^delete o[p], ...^delete o[q]]`
+    # `^delete o{p, q}` => `{p: ^delete o.p, q: ^delete o.q}`
     compile-spread: (o) ->
         {it} = this
         ops = [this]
         while it instanceof constructor, it.=it then ops.push it
-        return '' unless it.=expand-slice(o)unwrap! instanceof Arr
-                 and (them = it.items)length
+        is-spread =
+            it.=expand-slice(0)unwrap! instanceof Arr or
+            is-obj = it instanceof Obj and not do -> for ops
+                return true if ..op not in <[ ~ ! new do delete jsdelete ++ -- ]>
+        return '' unless is-spread and (them = it.items)length
         for node, i in them
-            node.=it if sp = node instanceof Splat
+            if sp = node instanceof Splat then node.=it
+            else if is-obj then node.=val
             for op in ops by -1 then node = constructor op.op, node, op.post
-            them[i] = if sp then lat = Splat node else node
+            if sp then them[i] = lat = Splat node
+            else if is-obj then them[i].val = node
+            else them[i] = node
         if not lat and (@void or not o.level)
-            it = Block(them) <<< {@front, +void}
+            it = Block(if is-obj then [..val for them] else them) <<< {@front, +void}
         it.compile o, LEVEL_PAREN
 
     # `v = delete o.k`

--- a/test/operator.ls
+++ b/test/operator.ls
@@ -257,6 +257,13 @@ eq 3, a.2
 fn = null
 eq void fn? do then 4;5
 
+loaders =
+  a: -> 1
+  b: -> 2
+  more: -> c: 3, d: 4
+x = do loaders{a, b, ...more}
+ok x === { a: 1 b: 2 c: 3 d: 4 }
+
 
 ### `import`
 x = 'xx'
@@ -371,6 +378,12 @@ a = delete a.0
 eq 1 a
 eq 0 b.0
 
+x = a: 1 b: 2 c: 3
+y = delete x{a, z: b}
+ok x === {c: 3}
+ok y === {a: 1, z: 2}
+
+
 ### `jsdelete`
 
 x =
@@ -378,6 +391,13 @@ x =
 
 ok delete! x.1
 ok not delete! Math.PI
+
+x = a: 1 b: 2 c: 3
+Object.defineProperty x, \d, writable: false, enumerable: true
+ok (delete! x{a, b}) === {+a, +b}
+ok x === {c: 3, d: undefined}
+ok (delete! x{c, d}) === {+c, -d}
+ok x === {d: undefined}
 
 
 ### [[Class]] sniffing


### PR DESCRIPTION
<table>
<thead>
<th>Livescript</th>
<th>Compiled JavaScript</th>
</thead>
<tbody>
<tr>
<td>
<pre>x = delete a{b, c: d}</pre>
</td>
<td>
<pre>
var x, ref$;
x = {
  b: (ref$ = a.b, delete a.b, ref$),
  c: (ref$ = a.d, delete a.d, ref$)
};
</pre>
</td>
</tr>
<tr>
<td>
<pre>x = do loaders{plugins, preferences: {server, client}}</pre>
</td>
<td>
<pre>
var x;
x = {
  plugins: loaders.plugins(),
  preferences: {
    server: loaders.server(),
    client: loaders.client()
  }
};
</pre>
</td>
</tr>
</tbody>
</table>

Works almost exactly like unary spread over list literals/slices, but with that tasty object flavor.

I was originally going to support all unary operators, but then had a crisis of conscience when I looked at `^^{foo, bar}` and asked whether that ought to be equivalent to `x = {foo, bar}; ^^x` or `{^^foo, ^^bar}`, or whether someone would freak out if `typeof {} != typeof {foo:1}` (although both of these issues exist with list spreads right now, so...). The somewhat arbitrary list of operators I decided to support is `~` `!`/`not` `new` `do` `delete`/`delete!` `++` `--`, but I'm not terribly attached to most of those decisions. The two examples demonstrated above are the ones I want to use.

Feedback please!