### PR TITLE
ES7 `async`/`await` implementation with concise syntax

### DIFF
--- a/src/grammar.ls
+++ b/src/grammar.ls
@@ -277,11 +277,15 @@ bnf =
 
         # The function literal can be either anonymous with `->`,
         o 'PARAM( ArgList OptComma )PARAM -> Block'
-        , -> Fun $2, $6, /~/.test($5), /--|~~/.test($5), /!/.test($5), /\*/.test($5)
+        , -> Fun $2, $6, /~/.test($5), /--|~~/.test($5), /!/.test($5), /\*/.test($5), />>/.test($5)
+        o 'ASYNC PARAM( ArgList OptComma )PARAM -> Block'
+        , -> Fun $3, $7, /~/.test($6), /--|~~/.test($6), /!/.test($6), false, true
         # or named with `function`.
         o 'FUNCTION CALL( ArgList OptComma )CALL Block' -> (Fun $3, $6).named $1
         o 'GENERATOR CALL( ArgList OptComma )CALL Block'
-        , -> (Fun $3, $6, false, false, false, true).named $1
+        , -> (Fun $3, $6, false, false, false, true, false).named $1
+        o 'ASYNC FUNCTION CALL( ArgList OptComma )CALL Block'
+        , -> (Fun $4, $7, false, false, false, false, true).named $2
 
         # The full complement of `if` and `unless` expressions
         o 'IF Expression Block Else'      -> L 1 2 If $2, $3, $1 is 'unless' .add-else $4

--- a/src/grammar.ls
+++ b/src/grammar.ls
@@ -278,8 +278,6 @@ bnf =
         # The function literal can be either anonymous with `->`,
         o 'PARAM( ArgList OptComma )PARAM -> Block'
         , -> Fun $2, $6, /~/.test($5), /--|~~/.test($5), /!/.test($5), /\*/.test($5), />>/.test($5)
-        o 'ASYNC PARAM( ArgList OptComma )PARAM -> Block'
-        , -> Fun $3, $7, /~/.test($6), /--|~~/.test($6), /!/.test($6), false, true
         # or named with `function`.
         o 'FUNCTION CALL( ArgList OptComma )CALL Block' -> (Fun $3, $6).named $1
         o 'GENERATOR CALL( ArgList OptComma )CALL Block'

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -1036,7 +1036,7 @@ character = if not JSON? then uxxxx else ->
         case tag is 'ID' and val is 'async'
             next = tokens[i + 1]
             switch next.0
-            | 'PARAM(', 'FUNCTION' => token.0 = 'ASYNC'
+            | 'FUNCTION' => token.0 = 'ASYNC'
             | 'GENERATOR' => carp 'named generator cannot be async' line
         prev = token
         continue

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -143,7 +143,7 @@ exports <<<
             tag = 'LITERAL'
         case <[ new do typeof delete ]>
             tag = 'UNARY'
-        case 'yield'
+        case 'yield' 'await'
             tag = 'YIELD'
         case 'return' 'throw'
             tag = 'HURL'
@@ -239,6 +239,9 @@ exports <<<
                 if last.1 is '<<<' and '<'
                 or last.1 is 'import' and 'All'
                     last.1 += that
+                    return 3
+                if last.0 is 'yield' and last.1 is 'await'
+                    last.1 += 'all'
                     return 3
             case 'from'
                 if last.1 is 'yield'
@@ -655,7 +658,7 @@ exports <<<
             @fset 'for' false
             tag = 'THEN'
         default
-            if /^!?(?:--?|~~?)>\*?$/.test val # function arrow
+            if /^!?(?:--?|~~?)>(?:>|\*)?$/.test val # function arrow
                 @parameters tag = '->'
             else if /^\*?<(?:--?|~~?)!?$/.test val # backcall
                 @parameters tag = '<-'
@@ -1030,6 +1033,11 @@ character = if not JSON? then uxxxx else ->
                                 [')PARAM' ')'  line, column]
                                 ['->'     '~>' line, column]
                             break LOOP
+        case tag is 'ID' and val is 'async'
+            next = tokens[i + 1]
+            switch next.0
+            | 'PARAM(', 'FUNCTION' => token.0 = 'ASYNC'
+            | 'GENERATOR' => carp 'named generator cannot be async' line
         prev = token
         continue
 
@@ -1344,7 +1352,7 @@ SYMBOL = //
 | \.{1,3}                       # dot / cascade / splat/placeholder/yada*3
 | \^\^                          # clone
 | \*?<(?:--?|~~?)!?             # backcall
-| !?(?:--?|~~?)>\*?             # function, bound function
+| !?(?:--?|~~?)>(?:>|\*)?       # function, bound function
 | ([-+&|:])\1                   # crement / logic / `prototype`
 | %%                            # mod
 | &                             # arguments


### PR DESCRIPTION
[ES7 async/await](http://wiki.ecmascript.org/doku.php?id=strawman:async_functions) is a syntax sugar for promise+generator async control pattern. Although this feature is still a draft in even ES7, it has gained considerable traction, and is completely usable right now through [a babel plugin](http://masnun.com/2015/11/11/using-es7-asyncawait-today-with-babel.html).

This patch provides a concrete example on which we can discuss syntax extensions to LiveScript that compiles to ES7 async/await.
# `async function`
1. Append an additional `>` to all arrows: `->>`, `~>>`, `-->>`, `~~>>`
   Rationale for the syntax: terseness
2. ~~Prepend keyword `async` to arglist of arrow functions: `async (arglist) -> body`
   Rationale for the syntax: agrees with [strawman](http://wiki.ecmascript.org/doku.php?id=strawman:async_functions) proposal on async "ES6 rocket" functions~~ (redundant)
3. Prepend keyword `async` to named function definitions: `async function name(arglist)`
   Rationale for the syntax: obvious
# `await` expression
1. `await` compiles to `await` (in the same way as how `yield` is compiled now)
2. ~~`await all` compiles to `await*` (in the same way as how `yield from` is compiled now)
   Rationale:  `await*` is proposed to have the same semantics as `Promise.all` (see [strawman](http://wiki.ecmascript.org/doku.php?id=strawman:async_functions))~~ (no longer in standard)
# Example

``` livescript
af1 = (x) ->> await x
af2 = async (a, b, c) ~> await @x
async function af3(x)
  a = await af1 x
```

compiles to

``` javascript
var af1, af2, this$ = this;
af1 = async function(x){
  return (await x);
};
af2 = async function(a, b, c){
  return (await this$.x);
};
async function af3(x){
  var a;
  return a = (await af1(x));
}
```
# References
- [Official Strawman Proposal](http://wiki.ecmascript.org/doku.php?id=strawman:async_functions)
- [Example of async/await usage](http://code.tutsplus.com/tutorials/a-primer-on-es7-async-functions--cms-22367)
- [Babel plugins for transpiling ES7 async/await to ES5](http://masnun.com/2015/11/11/using-es7-asyncawait-today-with-babel.html)
- #752 #754 : prior art
- #811 : LiveScript "2.0" checklist
