### PR TITLE
add robustness to generated loop code

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -274,10 +274,14 @@ SourceNode::to-string = (...args) ->
       return [sub, ref, [ref.value]];
     }
   },
-  compileLoopReference: function(o, name, ret){
-    var ref$, asn, tmp;
+  compileLoopReference: function(o, name, ret, safeAccess){
+    var ref$, code, asn, tmp;
     if (this instanceof Var && o.scope.check(this.value) || this instanceof Unary && ((ref$ = this.op) === '+' || ref$ === '-') && (-1 / 0 < (ref$ = +this.it.value) && ref$ < 1 / 0) || this instanceof Literal && !this.isComplex()) {
-      return [ref$ = this.compile(o), ref$];
+      code = this.compile(o, LEVEL_PAREN);
+      if (safeAccess && !(this instanceof Var)) {
+        code = "(" + code + ")";
+      }
+      return [code, code];
     }
     asn = Assign(Var(tmp = o.scope.temporary(name)), this);
     ret || (asn['void'] = true);
@@ -3695,7 +3699,7 @@ exports.For = For = (function(superclass){
         this.item = Var(o.scope.temporary('x'));
       }
       if (this.item || this.object && this.own || this['let']) {
-        ref$ = this.source.compileLoopReference(o, 'ref', !this.object), svar = ref$[0], srcPart = ref$[1];
+        ref$ = this.source.compileLoopReference(o, 'ref', !this.object, true), svar = ref$[0], srcPart = ref$[1];
         svar === srcPart || temps.push(svar);
       } else {
         svar = srcPart = this.source.compile(o, LEVEL_PAREN);

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -900,11 +900,6 @@ exports.doLiteral = function(code, index){
     }
     tag = 'UNARY';
     break;
-  case '&':
-    if (!able(this.tokens)) {
-      tag = 'LITERAL';
-    }
-    break;
   case '|':
     tag = 'BITWISE';
     break;

--- a/test/loop.ls
+++ b/test/loop.ls
@@ -686,3 +686,13 @@ eq 1, i
 o = { [k, -> v] for let k, v of {a: 1, b: 2} }
 eq 1 o.a!
 eq 2 o.b!
+
+# Certain literals could result in illegal JavaScript if not carefully
+# handled. These are all nonsensical use cases and could just as easily
+# be LiveScript syntax errors. The thing to avoid is for them to be JavaScript
+# syntax errors; lsc should never produce illegal JavaScript on any input,
+# silly or otherwise.
+deep-equal [] [0 for x in 42]
+deep-equal [] [0 for x in -42]
+throws "Cannot read property 'length' of null" -> [0 for x in null]
+throws "Cannot read property 'length' of undefined" -> [0 for x in void]


### PR DESCRIPTION
Certain expressions—integers (with or without a preceding +/-), null,
and void—when used as sources of for loops resulted in illegal
JavaScript being generated. While (42).length is a silly but legal thing
to do, 42.length is an actual SyntaxError in JS. This commit adds checks
to wrap potentially problematic expressions in parentheses.