### PR TITLE
fix keyword literals in object slices

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -757,6 +757,13 @@ exports.Literal = Literal = (function(superclass){
       return superclass.prototype.makeReturn.apply(this, arguments);
     }
   };
+  prototype.maybeKey = function(){
+    if (ID.test(this.value)) {
+      return Key(this.value);
+    } else {
+      return this;
+    }
+  };
   prototype.compile = function(o, level){
     var val, ref$;
     level == null && (level = o.level);

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -508,6 +508,8 @@ class exports.Literal extends Atom
         else
             super ...
 
+    maybe-key: -> if ID.test @value then Key @value else this
+
     compile: (o, level ? o.level) ->
         switch val = "#{@value}"
         | \this      => return sn(this, o.scope.fun?bound or val)

--- a/test/chaining.ls
+++ b/test/chaining.ls
@@ -224,3 +224,11 @@ eq void f!?p
 
 f = void
 eq void f?!
+
+# Keyword literals in object slices
+keywords = arguments: 1 eval: 2 void: 3 on: 4 debugger: 5
+eq 1 keywords{arguments}arguments
+eq 2 keywords{eval}eval
+eq 3 keywords{void}void
+eq 4 keywords{on}on
+eq 5 keywords{debugger}debugger


### PR DESCRIPTION
Prior to this commit, a keyword literal such as `arguments` was treated the same way as a literal like `0` when creating object slices—so instead of `x{arguments}` meaning `{arguments: x.arguments}`, you got `{arguments: x[arguments]}`.