### PR TITLE
Enable better Browserify detection.

### DIFF
--- a/package.json.ls
+++ b/package.json.ls
@@ -28,6 +28,7 @@ files:
   'LICENSE'
 
 main: './lib/'
+browser: './lib/browser.js'
 bin:
   lsc: './bin/lsc'
 


### PR DESCRIPTION
It makes the JS compiler much easier to use with Browserify CDNs like wzrd.in, brcdn.org, etc. It shouldn't affect browser usage for existing consumers beyond what would already throw errors normally.

(Helpful for testing in browsers, where you don't have to create your own LS bundle manually just to use this feature).

Do note that this doesn't clean up all the other remaining references lying around everywhere.