### PR TITLE
use full ClassName.prototype.memberName

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -524,12 +524,12 @@ exports.Block = Block = (function(superclass){
     }
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['lines'];
-  prototype.toJSON = function(){
+  Block.prototype.children = ['lines'];
+  Block.prototype.toJSON = function(){
     delete this.back;
     return superclass.prototype.toJSON.call(this);
   };
-  prototype.add = function(it){
+  Block.prototype.add = function(it){
     var that, ref$;
     it = it.unparen();
     switch (false) {
@@ -547,12 +547,12 @@ exports.Block = Block = (function(superclass){
     }
     return this;
   };
-  prototype.prepend = function(){
+  Block.prototype.prepend = function(){
     var ref$;
     (ref$ = this.lines).splice.apply(ref$, [this.neck(), 0].concat(slice$.call(arguments)));
     return this;
   };
-  prototype.pipe = function(target, type){
+  Block.prototype.pipe = function(target, type){
     var args;
     args = type === '|>' ? this.lines.pop() : target;
     if (toString$.call(args).slice(8, -1) !== 'Array') {
@@ -569,14 +569,14 @@ exports.Block = Block = (function(superclass){
     }
     return this;
   };
-  prototype.unwrap = function(){
+  Block.prototype.unwrap = function(){
     if (this.lines.length === 1) {
       return this.lines[0];
     } else {
       return this;
     }
   };
-  prototype.chomp = function(){
+  Block.prototype.chomp = function(){
     var lines, i, that;
     lines = this.lines;
     i = lines.length;
@@ -588,7 +588,7 @@ exports.Block = Block = (function(superclass){
     lines.length = i + 1;
     return this;
   };
-  prototype.neck = function(){
+  Block.prototype.neck = function(){
     var pos, i$, ref$, len$, x;
     pos = 0;
     for (i$ = 0, len$ = (ref$ = this.lines).length; i$ < len$; ++i$) {
@@ -600,7 +600,7 @@ exports.Block = Block = (function(superclass){
     }
     return pos;
   };
-  prototype.isComplex = function(){
+  Block.prototype.isComplex = function(){
     var ref$;
     return this.lines.length > 1 || ((ref$ = this.lines[0]) != null ? ref$.isComplex() : void 8);
   };
@@ -608,7 +608,7 @@ exports.Block = Block = (function(superclass){
     var ref$, ref1$;
     return (ref$ = (ref1$ = this.lines)[ref1$.length - 1]) != null ? ref$[it]() : void 8;
   });
-  prototype.getJump = function(it){
+  Block.prototype.getJump = function(it){
     var i$, ref$, len$, node, that;
     for (i$ = 0, len$ = (ref$ = this.lines).length; i$ < len$; ++i$) {
       node = ref$[i$];
@@ -617,7 +617,7 @@ exports.Block = Block = (function(superclass){
       }
     }
   };
-  prototype.makeReturn = function(){
+  Block.prototype.makeReturn = function(){
     var that, ref$, key$, ref1$;
     this.chomp();
     if (that = (ref1$ = ref$ = this.lines)[key$ = ref1$.length - 1] != null ? ref$[key$] = (ref$ = ref$[key$]).makeReturn.apply(ref$, arguments) : void 8) {
@@ -627,7 +627,7 @@ exports.Block = Block = (function(superclass){
     }
     return this;
   };
-  prototype.compile = function(o, level){
+  Block.prototype.compile = function(o, level){
     var tab, codes, i$, ref$, len$, node, code;
     level == null && (level = o.level);
     if (level) {
@@ -650,7 +650,7 @@ exports.Block = Block = (function(superclass){
     codes.pop();
     return sn.apply(null, [null].concat(slice$.call(codes)));
   };
-  prototype.compileRoot = function(options){
+  Block.prototype.compileRoot = function(options){
     var o, that, ref$, bare, prefix, ref1$, code, result;
     o = (import$({
       level: LEVEL_TOP,
@@ -675,7 +675,7 @@ exports.Block = Block = (function(superclass){
     bare || (code = ["(function(){\n"].concat(slice$.call(code), ["\n}).call(this);\n"]));
     return result = sn.apply(null, [null, prefix || []].concat(slice$.call(code)));
   };
-  prototype.compileWithDeclarations = function(o){
+  Block.prototype.compileWithDeclarations = function(o){
     var pre, i, rest, post, that;
     o.level = LEVEL_TOP;
     pre = [];
@@ -689,7 +689,7 @@ exports.Block = Block = (function(superclass){
     }
     return sn.apply(null, [null].concat(slice$.call(pre), [(that = this.scope) ? that.emit(post, o.indent) : post]));
   };
-  prototype.compileExpressions = function(o, level){
+  Block.prototype.compileExpressions = function(o, level){
     var lines, i, that, code, last, i$, len$, node;
     lines = this.chomp().lines;
     i = -1;
@@ -723,10 +723,10 @@ exports.Block = Block = (function(superclass){
 }(Node));
 Atom = (function(superclass){
   var prototype = extend$((import$(Atom, superclass).displayName = 'Atom', Atom), superclass).prototype, constructor = Atom;
-  prototype.show = function(){
+  Atom.prototype.show = function(){
     return this.value;
   };
-  prototype.isComplex = NO;
+  Atom.prototype.isComplex = NO;
   function Atom(){
     Atom.superclass.apply(this, arguments);
   }
@@ -745,24 +745,24 @@ exports.Literal = Literal = (function(superclass){
     }
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.isEmpty = function(){
+  Literal.prototype.isEmpty = function(){
     var ref$;
     return (ref$ = this.value) === 'void' || ref$ === 'null';
   };
-  prototype.isCallable = function(){
+  Literal.prototype.isCallable = function(){
     var ref$;
     return (ref$ = this.value) === 'this' || ref$ === 'eval' || ref$ === '..';
   };
-  prototype.isString = function(){
+  Literal.prototype.isString = function(){
     return 0 <= '\'"'.indexOf((this.value + "").charAt());
   };
-  prototype.isRegex = function(){
+  Literal.prototype.isRegex = function(){
     return (this.value + "").charAt() === '/';
   };
-  prototype.isComplex = function(){
+  Literal.prototype.isComplex = function(){
     return this.isRegex() || this.value === 'debugger';
   };
-  prototype.isWhat = function(){
+  Literal.prototype.isWhat = function(){
     switch (false) {
     case !this.isEmpty():
       return 'empty';
@@ -778,28 +778,28 @@ exports.Literal = Literal = (function(superclass){
 
     }
   };
-  prototype.varName = function(){
+  Literal.prototype.varName = function(){
     if (/^\w+$/.test(this.value)) {
       return '$' + this.value;
     } else {
       return '';
     }
   };
-  prototype.makeReturn = function(it){
+  Literal.prototype.makeReturn = function(it){
     if (!it && this.value === 'debugger') {
       return this;
     } else {
       return superclass.prototype.makeReturn.apply(this, arguments);
     }
   };
-  prototype.maybeKey = function(){
+  Literal.prototype.maybeKey = function(){
     if (ID.test(this.value)) {
       return Key(this.value);
     } else {
       return this;
     }
   };
-  prototype.compile = function(o, level){
+  Literal.prototype.compile = function(o, level){
     var val, ref$;
     level == null && (level = o.level);
     switch (val = this.value + "") {
@@ -850,15 +850,15 @@ exports.Var = Var = (function(superclass){
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
   prototype.isAssignable = prototype.isCallable = YES;
-  prototype.assigns = function(it){
+  Var.prototype.assigns = function(it){
     return it === this.value;
   };
-  prototype.maybeKey = function(){
+  Var.prototype.maybeKey = function(){
     var ref$;
     return ref$ = Key(this.value), ref$.line = this.line, ref$;
   };
-  prototype.varName = prototype.show;
-  prototype.compile = function(o){
+  Var.prototype.varName = prototype.show;
+  Var.prototype.compile = function(o){
     return sn(this, this.temp
       ? o.scope.free(this.value)
       : this.value);
@@ -873,11 +873,11 @@ exports.Key = Key = (function(superclass){
     this$.name = '' + name;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.isComplex = NO;
-  prototype.assigns = function(it){
+  Key.prototype.isComplex = NO;
+  Key.prototype.assigns = function(it){
     return it === this.name;
   };
-  prototype.varName = function(){
+  Key.prototype.varName = function(){
     var name;
     name = this.name;
     if (this.reserved || (name === 'arguments' || name === 'eval')) {
@@ -886,14 +886,14 @@ exports.Key = Key = (function(superclass){
       return name;
     }
   };
-  prototype.show = function(){
+  Key.prototype.show = function(){
     if (this.reserved) {
       return "'" + this.name + "'";
     } else {
       return this.name;
     }
   };
-  prototype.compile = function(){
+  Key.prototype.compile = function(){
     return sn(this, this.show());
   };
   return Key;
@@ -927,18 +927,18 @@ exports.Index = Index = (function(superclass){
     this$.symbol = symbol;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['key'];
-  prototype.show = function(){
+  Index.prototype.children = ['key'];
+  Index.prototype.show = function(){
     return [this.soak ? '?' : void 8] + this.symbol;
   };
-  prototype.isComplex = function(){
+  Index.prototype.isComplex = function(){
     return this.key.isComplex();
   };
-  prototype.varName = function(){
+  Index.prototype.varName = function(){
     var ref$;
     return ((ref$ = this.key) instanceof Key || ref$ instanceof Literal) && this.key.varName();
   };
-  prototype.compile = function(o){
+  Index.prototype.compile = function(o){
     var code;
     code = this.key.compile(o, LEVEL_PAREN);
     if (this.key instanceof Key && '\'' !== code.toString().charAt(0)) {
@@ -960,11 +960,11 @@ exports.Slice = Slice = (function(superclass){
     }
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['target', 'from', 'to'];
-  prototype.show = function(){
+  Slice.prototype.children = ['target', 'from', 'to'];
+  Slice.prototype.show = function(){
     return this.type;
   };
-  prototype.compileNode = function(o){
+  Slice.prototype.compileNode = function(o){
     var args;
     if (this.to && this.type === 'to') {
       this.to = Binary('||', this.to, Literal('9e9'));
@@ -988,8 +988,8 @@ exports.Chain = Chain = (function(superclass){
     this$.tails = tails || [];
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['head', 'tails'];
-  prototype.add = function(it){
+  Chain.prototype.children = ['head', 'tails'];
+  Chain.prototype.add = function(it){
     var last, ref$, index, ref1$, bi, logics, call, f;
     if (this.tails.length) {
       last = (ref$ = this.tails)[ref$.length - 1];
@@ -1034,7 +1034,7 @@ exports.Chain = Chain = (function(superclass){
     }
     return this;
   };
-  prototype.autoCompare = function(target){
+  Chain.prototype.autoCompare = function(target){
     var test;
     test = this.head;
     switch (false) {
@@ -1050,11 +1050,11 @@ exports.Chain = Chain = (function(superclass){
       return this.add(Call(target)) || [];
     }
   };
-  prototype.flipIt = function(){
+  Chain.prototype.flipIt = function(){
     this.flip = true;
     return this;
   };
-  prototype.unwrap = function(){
+  Chain.prototype.unwrap = function(){
     if (this.tails.length) {
       return this;
     } else {
@@ -1064,10 +1064,10 @@ exports.Chain = Chain = (function(superclass){
   prototype.delegate(['getJump', 'assigns', 'isStatement', 'isString'], function(it, arg){
     return !this.tails.length && this.head[it](arg);
   });
-  prototype.isComplex = function(){
+  Chain.prototype.isComplex = function(){
     return this.tails.length || this.head.isComplex();
   };
-  prototype.isCallable = function(){
+  Chain.prototype.isCallable = function(){
     var that, ref$;
     if (that = (ref$ = this.tails)[ref$.length - 1]) {
       return !((ref$ = that.key) != null && ref$.items);
@@ -1075,7 +1075,7 @@ exports.Chain = Chain = (function(superclass){
       return this.head.isCallable();
     }
   };
-  prototype.isArray = function(){
+  Chain.prototype.isArray = function(){
     var that, ref$;
     if (that = (ref$ = this.tails)[ref$.length - 1]) {
       return that.key instanceof Arr;
@@ -1083,10 +1083,10 @@ exports.Chain = Chain = (function(superclass){
       return this.head.isArray();
     }
   };
-  prototype.isRegex = function(){
+  Chain.prototype.isRegex = function(){
     return this.head.value === 'RegExp' && !this.tails[1] && this.tails[0] instanceof Call;
   };
-  prototype.isAssignable = function(){
+  Chain.prototype.isAssignable = function(){
     var tail, ref$, i$, len$;
     if (!(tail = (ref$ = this.tails)[ref$.length - 1])) {
       return this.head.isAssignable();
@@ -1102,10 +1102,10 @@ exports.Chain = Chain = (function(superclass){
     }
     return true;
   };
-  prototype.isSimpleAccess = function(){
+  Chain.prototype.isSimpleAccess = function(){
     return this.tails.length === 1 && !this.head.isComplex() && !this.tails[0].isComplex();
   };
-  prototype.makeReturn = function(){
+  Chain.prototype.makeReturn = function(){
     var ref$;
     if (this.tails.length) {
       return superclass.prototype.makeReturn.apply(this, arguments);
@@ -1113,15 +1113,15 @@ exports.Chain = Chain = (function(superclass){
       return (ref$ = this.head).makeReturn.apply(ref$, arguments);
     }
   };
-  prototype.getCall = function(){
+  Chain.prototype.getCall = function(){
     var tail, ref$;
     return (tail = (ref$ = this.tails)[ref$.length - 1]) instanceof Call && tail;
   };
-  prototype.varName = function(){
+  Chain.prototype.varName = function(){
     var ref$, ref1$;
     return (ref$ = (ref1$ = this.tails)[ref1$.length - 1]) != null ? ref$.varName() : void 8;
   };
-  prototype.cacheReference = function(o){
+  Chain.prototype.cacheReference = function(o){
     var name, ref$, base, ref, bref, nref;
     name = (ref$ = this.tails)[ref$.length - 1];
     if (!this.isAssignable()) {
@@ -1146,7 +1146,7 @@ exports.Chain = Chain = (function(superclass){
     }
     return [base.add(name), Chain(bref || base.head, [nref || name])];
   };
-  prototype.compileNode = function(o){
+  Chain.prototype.compileNode = function(o){
     var head, tails, that, i$, len$, t, hasPartial, pre, rest, broken, partial, post, context, idt, func, base, news, ref$;
     if (this.flip) {
       util('flip');
@@ -1221,7 +1221,7 @@ exports.Chain = Chain = (function(superclass){
     }
     return sn.apply(null, [null].concat(slice$.call(news), slice$.call(base), slice$.call(rest)));
   };
-  prototype.unfoldSoak = function(o){
+  Chain.prototype.unfoldSoak = function(o){
     var that, ref$, i$, len$, i, node, ref1$, bust, test;
     if (that = this.head.unfoldSoak(o)) {
       (ref$ = that.then.tails).push.apply(ref$, this.tails);
@@ -1252,7 +1252,7 @@ exports.Chain = Chain = (function(superclass){
       }
     }
   };
-  prototype.unfoldAssign = function(o){
+  Chain.prototype.unfoldAssign = function(o){
     var that, ref$, i$, len$, i, index, op, left, lefts, rites, j$, len1$, node, ref1$;
     if (that = this.head.unfoldAssign(o)) {
       (ref$ = that.right.tails).push.apply(ref$, this.tails);
@@ -1282,7 +1282,7 @@ exports.Chain = Chain = (function(superclass){
       }
     }
   };
-  prototype.expandSplat = function(o){
+  Chain.prototype.expandSplat = function(o){
     var tails, i, call, args, ctx, ref$;
     tails = this.tails;
     i = -1;
@@ -1306,7 +1306,7 @@ exports.Chain = Chain = (function(superclass){
       }
     }
   };
-  prototype.expandVivify = function(){
+  Chain.prototype.expandVivify = function(){
     var tails, i, that, ref$, ref1$;
     tails = this.tails;
     i = 0;
@@ -1317,7 +1317,7 @@ exports.Chain = Chain = (function(superclass){
       }
     }
   };
-  prototype.expandBind = function(o){
+  Chain.prototype.expandBind = function(o){
     var tails, i, that, obj, key, call;
     tails = this.tails;
     i = -1;
@@ -1333,7 +1333,7 @@ exports.Chain = Chain = (function(superclass){
       i = -1;
     }
   };
-  prototype.expandStar = function(o){
+  Chain.prototype.expandStar = function(o){
     var tails, i, that, stars, ref$, sub, ref, temps, value, i$, len$, star;
     tails = this.tails;
     i = -1;
@@ -1367,7 +1367,7 @@ exports.Chain = Chain = (function(superclass){
       }
     }
   };
-  prototype.expandSlice = function(o, assign){
+  Chain.prototype.expandSlice = function(o, assign){
     var tails, i, tail, ref$, x;
     tails = this.tails;
     i = -1;
@@ -1415,11 +1415,11 @@ exports.Call = Call = (function(superclass){
     this$.args = args;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['args'];
-  prototype.show = function(){
+  Call.prototype.children = ['args'];
+  Call.prototype.show = function(){
     return [this['new']] + [this.method] + [this.soak ? '?' : void 8];
   };
-  prototype.compile = function(o){
+  Call.prototype.compile = function(o){
     var code, i$, ref$, len$, i, a;
     code = [sn(this, this.method || '', '(') + (this.pipe ? "\n" + o.indent : '')];
     for (i$ = 0, len$ = (ref$ = this.args).length; i$ < len$; ++i$) {
@@ -1492,18 +1492,18 @@ exports.Call = Call = (function(superclass){
 }(Node));
 List = (function(superclass){
   var prototype = extend$((import$(List, superclass).displayName = 'List', List), superclass).prototype, constructor = List;
-  prototype.children = ['items'];
-  prototype.show = function(){
+  List.prototype.children = ['items'];
+  List.prototype.show = function(){
     return this.name;
   };
-  prototype.named = function(name){
+  List.prototype.named = function(name){
     this.name = name;
     return this;
   };
-  prototype.isEmpty = function(){
+  List.prototype.isEmpty = function(){
     return !this.items.length;
   };
-  prototype.assigns = function(it){
+  List.prototype.assigns = function(it){
     var i$, ref$, len$, node;
     for (i$ = 0, len$ = (ref$ = this.items).length; i$ < len$; ++i$) {
       node = ref$[i$];
@@ -1555,8 +1555,8 @@ exports.Obj = Obj = (function(superclass){
     this$.items = items || [];
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.asObj = THIS;
-  prototype.toSlice = function(o, base, symbol, assign){
+  Obj.prototype.asObj = THIS;
+  Obj.prototype.toSlice = function(o, base, symbol, assign){
     var items, ref$, ref, temps, i$, len$, i, node, name, chain, logic, key, val;
     items = this.items;
     if (items.length > 1) {
@@ -1599,7 +1599,7 @@ exports.Obj = Obj = (function(superclass){
     }
     return this;
   };
-  prototype.compileNode = function(o){
+  Obj.prototype.compileNode = function(o){
     var items, code, idt, dic, i$, len$, i, node, logic, rest, ref$, multi, key, val;
     items = this.items;
     if (!items.length) {
@@ -1690,15 +1690,15 @@ exports.Prop = Prop = (function(superclass){
     }
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['key', 'val'];
-  prototype.show = function(){
+  Prop.prototype.children = ['key', 'val'];
+  Prop.prototype.show = function(){
     return this.accessor;
   };
-  prototype.assigns = function(it){
+  Prop.prototype.assigns = function(it){
     var ref$;
     return typeof (ref$ = this.val).assigns == 'function' ? ref$.assigns(it) : void 8;
   };
-  prototype.compileAccessor = function(o, key){
+  Prop.prototype.compileAccessor = function(o, key){
     var funs, code, i$, len$, fun;
     funs = this.val;
     if (funs[1] && funs[0].params.length + funs[1].params.length !== 1) {
@@ -1713,7 +1713,7 @@ exports.Prop = Prop = (function(superclass){
     code.pop();
     return sn.apply(null, [null].concat(slice$.call(code)));
   };
-  prototype.compileDescriptor = function(o){
+  Prop.prototype.compileDescriptor = function(o){
     var obj, i$, ref$, len$, fun;
     obj = Obj();
     for (i$ = 0, len$ = (ref$ = this.val).length; i$ < len$; ++i$) {
@@ -1733,8 +1733,8 @@ exports.Arr = Arr = (function(superclass){
     this$.items = items || [];
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.isArray = YES;
-  prototype.asObj = function(){
+  Arr.prototype.isArray = YES;
+  Arr.prototype.asObj = function(){
     var i, item;
     return Obj((function(){
       var i$, ref$, len$, results$ = [];
@@ -1746,7 +1746,7 @@ exports.Arr = Arr = (function(superclass){
       return results$;
     }.call(this)));
   };
-  prototype.toSlice = function(o, base, symbol){
+  Arr.prototype.toSlice = function(o, base, symbol){
     var items, ref$, ref, i$, len$, i, item, splat, chain;
     items = this.items;
     if (items.length > 1) {
@@ -1770,7 +1770,7 @@ exports.Arr = Arr = (function(superclass){
     chain || this.carp('empty slice');
     return this;
   };
-  prototype.compile = function(o){
+  Arr.prototype.compile = function(o){
     var items, code;
     items = this.items;
     if (!items.length) {
@@ -1802,8 +1802,8 @@ exports.Yield = Yield = (function(superclass){
     this$.it = it;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['it'];
-  prototype.show = function(){
+  Yield.prototype.children = ['it'];
+  Yield.prototype.show = function(){
     if (this.op === 'yieldfrom') {
       return 'from';
     } else {
@@ -1813,7 +1813,7 @@ exports.Yield = Yield = (function(superclass){
   prototype.delegate(['isCallable'], function(){
     return true;
   });
-  prototype.compileNode = function(o){
+  Yield.prototype.compileNode = function(o){
     var code;
     code = [];
     if (this.op === 'yieldfrom') {
@@ -1879,33 +1879,33 @@ exports.Unary = Unary = (function(superclass){
     this$.it = it;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['it'];
-  prototype.show = function(){
+  Unary.prototype.children = ['it'];
+  Unary.prototype.show = function(){
     return [this.post ? '@' : void 8] + this.op;
   };
-  prototype.isCallable = function(){
+  Unary.prototype.isCallable = function(){
     var ref$;
     return ((ref$ = this.op) === 'do' || ref$ === 'new' || ref$ === 'delete') || this.it == null;
   };
-  prototype.isArray = function(){
+  Unary.prototype.isArray = function(){
     return this.it instanceof Arr && this.it.items.length || this.it instanceof Chain && this.it.isArray();
   };
-  prototype.isString = function(){
+  Unary.prototype.isString = function(){
     var ref$;
     return (ref$ = this.op) === 'typeof' || ref$ === 'classof';
   };
-  prototype.invert = function(){
+  Unary.prototype.invert = function(){
     var ref$;
     if (this.op === '!' && ((ref$ = this.it.op) === '!' || ref$ === '<' || ref$ === '>' || ref$ === '<=' || ref$ === '>=' || ref$ === 'of' || ref$ === 'instanceof')) {
       return this.it;
     }
     return constructor('!', this, true);
   };
-  prototype.unfoldSoak = function(o){
+  Unary.prototype.unfoldSoak = function(o){
     var ref$;
     return ((ref$ = this.op) === '++' || ref$ === '--' || ref$ === 'delete') && this.it != null && If.unfoldSoak(o, this, 'it');
   };
-  prototype.getAccessors = function(){
+  Unary.prototype.getAccessors = function(){
     var items;
     if (this.op !== '~') {
       return;
@@ -1926,7 +1926,7 @@ exports.Unary = Unary = (function(superclass){
       '--': 'de'
     }[it] + 'crement';
   }
-  prototype.compileNode = function(o){
+  Unary.prototype.compileNode = function(o){
     var that, op, it, x, code;
     if (this.it == null) {
       return this.compileAsFunc(o);
@@ -1990,7 +1990,7 @@ exports.Unary = Unary = (function(superclass){
       return sn.apply(null, [this, "("].concat(slice$.call(code), [")"]));
     }
   };
-  prototype.compileSpread = function(o){
+  Unary.prototype.compileSpread = function(o){
     var it, ops;
     it = this.it;
     ops = [this];
@@ -2009,7 +2009,7 @@ exports.Unary = Unary = (function(superclass){
       return node;
     });
   };
-  prototype.compilePluck = function(o){
+  Unary.prototype.compilePluck = function(o){
     var ref$, get, del, code, ref;
     ref$ = Chain(this.it).cacheReference(o), get = ref$[0], del = ref$[1];
     code = [ref = o.scope.temporary(), " = ", get.compile(o, LEVEL_LIST), ", delete ", del.compile(o, LEVEL_LIST), ", ", o.scope.free(ref)];
@@ -2019,7 +2019,7 @@ exports.Unary = Unary = (function(superclass){
       return sn.apply(null, [this, "("].concat(slice$.call(code), [")"]));
     }
   };
-  prototype.compileAsFunc = function(o){
+  Unary.prototype.compileAsFunc = function(o){
     if (this.op === '!') {
       return sn(this, util('not'));
     } else {
@@ -2075,15 +2075,15 @@ exports.Binary = Binary = (function(superclass){
     this$.second = second;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['first', 'second'];
-  prototype.show = function(){
+  Binary.prototype.children = ['first', 'second'];
+  Binary.prototype.show = function(){
     return this.op;
   };
-  prototype.isCallable = function(){
+  Binary.prototype.isCallable = function(){
     var ref$;
     return this.partial || ((ref$ = this.op) === '&&' || ref$ === '||' || ref$ === '?' || ref$ === '<<' || ref$ === '>>') && this.first.isCallable() && this.second.isCallable();
   };
-  prototype.isArray = function(){
+  Binary.prototype.isArray = function(){
     switch (this.op) {
     case '*':
       return this.first.isArray();
@@ -2091,7 +2091,7 @@ exports.Binary = Binary = (function(superclass){
       return this.second.isMatcher();
     }
   };
-  prototype.isString = function(){
+  Binary.prototype.isString = function(){
     switch (this.op) {
     case '+':
     case '*':
@@ -2107,7 +2107,7 @@ exports.Binary = Binary = (function(superclass){
     '==': '!=',
     '!=': '=='
   };
-  prototype.invert = function(){
+  Binary.prototype.invert = function(){
     var that;
     if (that = !COMPARER.test(this.second.op) && INVERSIONS[this.op]) {
       this.op = that;
@@ -2116,11 +2116,11 @@ exports.Binary = Binary = (function(superclass){
     }
     return Unary('!', Parens(this), true);
   };
-  prototype.invertIt = function(){
+  Binary.prototype.invertIt = function(){
     this.inverted = true;
     return this;
   };
-  prototype.getDefault = function(){
+  Binary.prototype.getDefault = function(){
     switch (this.op) {
     case '?':
     case '||':
@@ -2128,7 +2128,7 @@ exports.Binary = Binary = (function(superclass){
       return this;
     }
   };
-  prototype.xorChildren = function(test){
+  Binary.prototype.xorChildren = function(test){
     var ref$, ref1$, first;
     if (!(!(ref$ = first = test(this.first)) !== !(ref1$ = test(this.second)) && (ref$ || ref1$))) {
       return false;
@@ -2137,7 +2137,7 @@ exports.Binary = Binary = (function(superclass){
       ? [this.first, this.second]
       : [this.second, this.first];
   };
-  prototype.compileNode = function(o){
+  Binary.prototype.compileNode = function(o){
     var top, rite, items, that, ref$, code, level, this$ = this;
     if (this.partial) {
       return this.compilePartial(o);
@@ -2232,7 +2232,7 @@ exports.Binary = Binary = (function(superclass){
       return sn.apply(null, [this, "("].concat(slice$.call(code), [")"]));
     }
   };
-  prototype.mapOp = function(op){
+  Binary.prototype.mapOp = function(op){
     var that;
     switch (false) {
     case !(that = op.match(/\.([&\|\^]|<<|>>>?)\./)):
@@ -2243,7 +2243,7 @@ exports.Binary = Binary = (function(superclass){
       return op;
     }
   };
-  prototype.compileChain = function(o){
+  Binary.prototype.compileChain = function(o){
     var code, level, ref$, sub;
     code = [this.first.compile(o, level = LEVEL_OP + PREC[this.op])];
     ref$ = this.second.first.cache(o, true), sub = ref$[0], this.second.first = ref$[1];
@@ -2254,7 +2254,7 @@ exports.Binary = Binary = (function(superclass){
       return sn.apply(null, [this, "("].concat(slice$.call(code), [")"]));
     }
   };
-  prototype.compileExistence = function(o){
+  Binary.prototype.compileExistence = function(o){
     var x;
     if (this['void'] || !o.level) {
       x = Binary('&&', Existence(this.first, true), this.second);
@@ -2263,7 +2263,7 @@ exports.Binary = Binary = (function(superclass){
     x = this.first.cache(o, true);
     return sn(this, If(Existence(x[0]), x[1]).addElse(this.second).compileExpression(o));
   };
-  prototype.compileAnyInstanceOf = function(o, items){
+  Binary.prototype.compileAnyInstanceOf = function(o, items){
     var ref$, sub, ref, test, i$, len$, item;
     ref$ = this.first.cache(o), sub = ref$[0], ref = ref$[1], this.temps = ref$[2];
     test = Binary('instanceof', sub, items.shift());
@@ -2273,14 +2273,14 @@ exports.Binary = Binary = (function(superclass){
     }
     return sn(this, Parens(test).compile(o));
   };
-  prototype.compileMinMax = function(o){
+  Binary.prototype.compileMinMax = function(o){
     var lefts, rites, x;
     lefts = this.first.cache(o, true);
     rites = this.second.cache(o, true);
     x = Binary(this.op.charAt(), lefts[0], rites[0]);
     return sn(this, If(x, lefts[1]).addElse(rites[1]).compileExpression(o));
   };
-  prototype.compileMethod = function(o, klass, method, arg){
+  Binary.prototype.compileMethod = function(o, klass, method, arg){
     var args;
     args = [this.second].concat(arg || []);
     if (this.first["is" + klass]()) {
@@ -2290,16 +2290,16 @@ exports.Binary = Binary = (function(superclass){
       return sn(this, Call.make(JS(util(method) + '.call'), args).compile(o));
     }
   };
-  prototype.compileJoin = function(it){
+  Binary.prototype.compileJoin = function(it){
     return this.compileMethod(it, 'Array', 'join');
   };
-  prototype.compileRemove = function(it){
+  Binary.prototype.compileRemove = function(it){
     return this.compileMethod(it, 'String', 'replace', JS("''"));
   };
-  prototype.compileSplit = function(it){
+  Binary.prototype.compileSplit = function(it){
     return this.compileMethod(it, 'String', 'split');
   };
-  prototype.compileRepeat = function(o){
+  Binary.prototype.compileRepeat = function(o){
     var x, n, items, arr, arrCode, refs, i$, len$, i, item, ref$, q;
     x = this.first, n = this.second;
     items = (x = x.expandSlice(o).unwrap()).items;
@@ -2343,10 +2343,10 @@ exports.Binary = Binary = (function(superclass){
       }
     }
   };
-  prototype.compilePow = function(o){
+  Binary.prototype.compilePow = function(o){
     return sn(null, Call.make(CopyL(this, JS('Math.pow')), [this.first, this.second]).compile(o));
   };
-  prototype.compileConcat = function(o){
+  Binary.prototype.compileConcat = function(o){
     var f;
     f = function(x){
       switch (false) {
@@ -2358,7 +2358,7 @@ exports.Binary = Binary = (function(superclass){
     };
     return sn(null, Chain(this.first).add(CopyL(this, Index(Key('concat'), '.', true))).add(Call(f(this.second))).compile(o));
   };
-  prototype.compileCompose = function(o){
+  Binary.prototype.compileCompose = function(o){
     var op, functions, x;
     op = this.op;
     functions = [this.first];
@@ -2373,14 +2373,14 @@ exports.Binary = Binary = (function(superclass){
     }
     return sn(this, Chain(Var(util('compose'))).add(Call(functions)).compile(o));
   };
-  prototype.compileMod = function(o){
+  Binary.prototype.compileMod = function(o){
     var ref, code;
     ref = o.scope.temporary();
     code = [sn(this, "((("), this.first.compile(o), sn(this, ") % ("), sn(this, ref, " = "), this.second.compile(o), sn(this, ") + ", ref, ") % ", ref, ")")];
     o.scope.free(ref);
     return sn.apply(null, [null].concat(slice$.call(code)));
   };
-  prototype.compilePartial = function(o){
+  Binary.prototype.compilePartial = function(o){
     var vit, x, y;
     vit = Var('it');
     switch (false) {
@@ -2394,7 +2394,7 @@ exports.Binary = Binary = (function(superclass){
       return sn(this, "(", Fun([vit], Block(Binary(this.op, vit, this.second).invertCheck(this)), true).compile(o), ")");
     }
   };
-  prototype.compileRegexEquals = function(o, arg$){
+  Binary.prototype.compileRegexEquals = function(o, arg$){
     var regex, target, method;
     regex = arg$[0], target = arg$[1];
     if (this.op === '===') {
@@ -2404,7 +2404,7 @@ exports.Binary = Binary = (function(superclass){
       return sn(this, Unary('!', Chain(regex).add(Index(Key('test'))).add(Call([target]))).compile(o));
     }
   };
-  prototype.compileDeepEq = function(o){
+  Binary.prototype.compileDeepEq = function(o){
     var ref$, negate, i$, len$, x, r;
     if ((ref$ = this.op) === '>==' || ref$ === '>>=') {
       ref$ = [this.second, this.first], this.first = ref$[0], this.second = ref$[1];
@@ -2423,7 +2423,7 @@ exports.Binary = Binary = (function(superclass){
     r = Chain(Var(util('deepEq'))).add(Call([this.first, this.second, Literal("'" + this.op + "'")]));
     return sn(this, (negate ? Unary('!', r) : r).compile(o));
   };
-  prototype.compileXor = function(o){
+  Binary.prototype.compileXor = function(o){
     var left, right;
     left = Chain(this.first).cacheReference(o);
     right = Chain(this.second).cacheReference(o);
@@ -2444,18 +2444,18 @@ exports.Assign = Assign = (function(superclass){
     this$[rite instanceof Node ? 'right' : 'unaries'] = rite;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['left', 'right'];
-  prototype.show = function(){
+  Assign.prototype.children = ['left', 'right'];
+  Assign.prototype.show = function(){
     return [void 8].concat(this.unaries).reverse().join(' ') + [this.logic] + this.op;
   };
-  prototype.assigns = function(it){
+  Assign.prototype.assigns = function(it){
     return this.left.assigns(it);
   };
   prototype.delegate(['isCallable', 'isRegex'], function(it){
     var ref$;
     return ((ref$ = this.op) === '=' || ref$ === ':=') && this.right && this.right[it]();
   });
-  prototype.isArray = function(){
+  Assign.prototype.isArray = function(){
     switch (this.op) {
     case '=':
     case ':=':
@@ -2464,7 +2464,7 @@ exports.Assign = Assign = (function(superclass){
       return this.right && this.right.isMatcher();
     }
   };
-  prototype.isString = function(){
+  Assign.prototype.isString = function(){
     switch (this.op) {
     case '=':
     case ':=':
@@ -2475,7 +2475,7 @@ exports.Assign = Assign = (function(superclass){
       return this.right && this.right.isMatcher();
     }
   };
-  prototype.unfoldSoak = function(o){
+  Assign.prototype.unfoldSoak = function(o){
     var that, ref$, ref1$, rite, temps;
     if (this.left instanceof Existence) {
       if (that = (ref1$ = (ref$ = this.left = this.left.it).name, delete ref$.name, ref1$)) {
@@ -2488,10 +2488,10 @@ exports.Assign = Assign = (function(superclass){
     }
     return If.unfoldSoak(o, this, 'left');
   };
-  prototype.unfoldAssign = function(){
+  Assign.prototype.unfoldAssign = function(){
     return this.access && this;
   };
-  prototype.compileNode = function(o){
+  Assign.prototype.compileNode = function(o){
     var left, sp, ref$, i$, len$, op, right, reft, sign, name, lvar, that, protoSplit, dotSplit, code, empty, res;
     if (this.left instanceof Slice && this.op === '=') {
       return this.compileSplice(o);
@@ -2566,7 +2566,7 @@ exports.Assign = Assign = (function(superclass){
     }
     return sn.apply(null, [null].concat(slice$.call(code)));
   };
-  prototype.compileConditional = function(o, left){
+  Assign.prototype.compileConditional = function(o, left){
     var lefts, morph;
     if (left instanceof Var && in$(this.logic, ['?']) && this.op === '=') {
       o.scope.declare(left.value, left);
@@ -2576,7 +2576,7 @@ exports.Assign = Assign = (function(superclass){
     morph = Binary(this.logic, lefts[0], (this.logic = false, this.left = lefts[1], this));
     return sn(this, (morph['void'] = this['void'], morph).compileNode(o));
   };
-  prototype.compileMinMax = function(o, left, right){
+  Assign.prototype.compileMinMax = function(o, left, right){
     var lefts, rites, test, put, ref$;
     lefts = Chain(left).cacheReference(o);
     rites = right.cache(o, true);
@@ -2588,7 +2588,7 @@ exports.Assign = Assign = (function(superclass){
     ref$ = test.first.cache(o, true), test.first = ref$[0], left = ref$[1];
     return sn(this, If(test, left).addElse(put).compileExpression(o));
   };
-  prototype.compileDestructuring = function(o, left){
+  Assign.prototype.compileDestructuring = function(o, left){
     var items, len, ret, rite, that, cache, rref, list, code, i$, len$, item;
     items = left.items, len = items.length;
     ret = o.level && !this['void'];
@@ -2623,14 +2623,14 @@ exports.Assign = Assign = (function(superclass){
       return sn.apply(null, [this, "("].concat(slice$.call(code), [")"]));
     }
   };
-  prototype.compileSplice = function(o){
+  Assign.prototype.compileSplice = function(o){
     var ref$, fromExpNode, fromExp, rightNode, right, toExp;
     ref$ = Chain(this.left.from).cacheReference(o), fromExpNode = ref$[0], fromExp = ref$[1];
     ref$ = Chain(this.right).cacheReference(o), rightNode = ref$[0], right = ref$[1];
     toExp = Binary('-', this.left.to, fromExp);
     return sn(this, Block([Chain(Var(util('splice'))).add(Index(Key('apply'), '.', true)).add(Call([this.left.target, Chain(Arr([fromExpNode, toExp])).add(Index(Key('concat'), '.', true)).add(Call([rightNode]))])), right]).compile(o, LEVEL_LIST));
   };
-  prototype.compileSpread = function(o, left){
+  Assign.prototype.compileSpread = function(o, left){
     var that, ref$, rite, rref, this$ = this;
     ref$ = (that = this.unaries)
       ? [that, that]
@@ -2644,7 +2644,7 @@ exports.Assign = Assign = (function(superclass){
       return result;
     });
   };
-  prototype.rendArr = function(o, nodes, rite){
+  Assign.prototype.rendArr = function(o, nodes, rite){
     var i$, len$, i, node, skip, len, val, ivar, start, inc, rcache, ref$, results$ = [];
     for (i$ = 0, len$ = nodes.length; i$ < len$; ++i$) {
       i = i$;
@@ -2688,7 +2688,7 @@ exports.Assign = Assign = (function(superclass){
       }
     }
   };
-  prototype.rendObj = function(o, nodes, rite){
+  Assign.prototype.rendObj = function(o, nodes, rite){
     var i$, len$, node, splat, logic, ref$, key, val, rcache, results$ = [];
     for (i$ = 0, len$ = nodes.length; i$ < len$; ++i$) {
       node = nodes[i$];
@@ -2733,14 +2733,14 @@ exports.Import = Import = (function(superclass){
     }
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['left', 'right'];
-  prototype.show = function(){
+  Import.prototype.children = ['left', 'right'];
+  Import.prototype.show = function(){
     return this.all;
   };
   prototype.delegate(['isCallable', 'isArray'], function(it){
     return this.left[it]();
   });
-  prototype.unfoldSoak = function(o){
+  Import.prototype.unfoldSoak = function(o){
     var left, value, ref$, temps;
     left = this.left;
     if (left instanceof Existence && !left.negated) {
@@ -2756,7 +2756,7 @@ exports.Import = Import = (function(superclass){
     }
     return If.unfoldSoak(o, this, 'left') || (this['void'] || !o.level) && If.unfoldSoak(o, this, 'right');
   };
-  prototype.compileNode = function(o){
+  Import.prototype.compileNode = function(o){
     var right;
     right = this.right;
     if (!this.all) {
@@ -2769,13 +2769,13 @@ exports.Import = Import = (function(superclass){
     }
     return CopyL(this, Call.make(Util("import" + (this.all || '')), [this.left, right])).compileNode(o);
   };
-  prototype.compileAssign = function(o, items){
+  Import.prototype.compileAssign = function(o, items){
     var top, reft, ref$, left, delim, space, code, i$, len$, i, node, com, logic, dyna, key, val;
     if (!items.length) {
       return this.left.compile(o);
     }
     top = !o.level;
-    if (items.length < 2 && (top || this['void'] || items[0] instanceof Splat)) {
+    if (this.proto || (items.length < 2 && (top || this['void'] || items[0] instanceof Splat))) {
       reft = this.left;
       if (reft.isComplex()) {
         reft = Parens(reft);
@@ -2842,8 +2842,8 @@ exports.In = In = (function(superclass){
     this.item = item;
     this.array = array;
   }
-  prototype.children = ['item', 'array'];
-  prototype.compileNode = function(o){
+  In.prototype.children = ['item', 'array'];
+  In.prototype.compileNode = function(o){
     var array, items, code, ref$, sub, ref, cmp, cnj, i$, len$, i, test;
     items = (array = this.array.expandSlice(o).unwrap()).items;
     if (!(array instanceof Arr) || items.length < 2) {
@@ -2889,8 +2889,8 @@ exports.Existence = Existence = (function(superclass){
     this$.negated = negated;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['it'];
-  prototype.compileNode = function(o){
+  Existence.prototype.children = ['it'];
+  Existence.prototype.compileNode = function(o){
     var node, ref$, code, op, eq;
     node = (ref$ = this.it.unwrap(), ref$.front = this.front, ref$);
     code = [node.compile(o, LEVEL_OP + PREC['=='])];
@@ -2922,34 +2922,34 @@ exports.Fun = Fun = (function(superclass){
     this$.generator = generator != null ? generator : false;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['params', 'body'];
-  prototype.show = function(){
+  Fun.prototype.children = ['params', 'body'];
+  Fun.prototype.show = function(){
     var that;
     return [this.name] + [(that = this.bound) ? "~" + that : void 8];
   };
-  prototype.named = function(it){
+  Fun.prototype.named = function(it){
     return this.name = it, this.statement = true, this;
   };
-  prototype.isCallable = YES;
-  prototype.isStatement = function(){
+  Fun.prototype.isCallable = YES;
+  Fun.prototype.isStatement = function(){
     return !!this.statement;
   };
-  prototype.traverseChildren = function(arg$, xscope){
+  Fun.prototype.traverseChildren = function(arg$, xscope){
     if (xscope) {
       return superclass.prototype.traverseChildren.apply(this, arguments);
     }
   };
-  prototype.makeReturn = function(){
+  Fun.prototype.makeReturn = function(){
     if (this.statement) {
       return this.returns = true, this;
     } else {
       return superclass.prototype.makeReturn.apply(this, arguments);
     }
   };
-  prototype.ripName = function(it){
+  Fun.prototype.ripName = function(it){
     this.name || (this.name = it.varName());
   };
-  prototype.compileNode = function(o){
+  Fun.prototype.compileNode = function(o){
     var pscope, sscope, scope, that, inLoop, ref$, body, name, tab, code, bodyCode, curryCodeCheck, this$ = this;
     pscope = o.scope;
     sscope = pscope.shared || pscope;
@@ -3030,7 +3030,7 @@ exports.Fun = Fun = (function(superclass){
       return sn.apply(null, [null].concat(slice$.call(code)));
     }
   };
-  prototype.compileParams = function(o, scope){
+  Fun.prototype.compileParams = function(o, scope){
     var params, length, body, i$, p, len$, i, splace, rest, that, names, assigns, dic, vr, df, unaries, hasUnary, v, ref$, ref1$;
     params = this.params, length = params.length, body = this.body;
     for (i$ = params.length - 1; i$ >= 0; --i$) {
@@ -3130,13 +3130,13 @@ exports.Class = Class = (function(superclass){
     this.title = arg$.title, this.sup = arg$.sup, this.mixins = arg$.mixins, body = arg$.body;
     this.fun = Fun([], body);
   }
-  prototype.children = ['title', 'sup', 'mixins', 'fun'];
-  prototype.isCallable = YES;
-  prototype.ripName = function(it){
+  Class.prototype.children = ['title', 'sup', 'mixins', 'fun'];
+  Class.prototype.isCallable = YES;
+  Class.prototype.ripName = function(it){
     this.name = it.varName();
   };
-  prototype.compile = function(o, level){
-    var fun, body, lines, title, boundFuncs, curriedBoundFuncs, decl, name, proto, ctorName, ctor, ctorPlace, importProtoObj, i$, len$, i, node, f, vname, args, that, imports, ref$, res$, clas;
+  Class.prototype.compile = function(o, level){
+    var fun, body, lines, title, boundFuncs, curriedBoundFuncs, decl, name, proto, vname, ctorName, ctor, ctorPlace, importProtoObj, i$, len$, i, node, f, args, that, imports, ref$, res$, clas;
     fun = this.fun, body = fun.body, lines = body.lines, title = this.title;
     CopyL(this, fun);
     boundFuncs = [];
@@ -3149,6 +3149,7 @@ exports.Class = Class = (function(superclass){
       name = 'constructor';
     }
     proto = Var('prototype');
+    vname = fun.proto = Var(fun.bound = name);
     ctorName = 'constructor$$';
     importProtoObj = function(node, i){
       var j, prop, key, i$, ref$, len$, v;
@@ -3186,7 +3187,7 @@ exports.Class = Class = (function(superclass){
         }
       }
       if (node.items.length) {
-        return Import(proto, node);
+        return ref$ = Import(Chain(vname).add(Index(Key('prototype'))), node), ref$.proto = true, ref$;
       } else {
         return Literal('void');
       }
@@ -3223,7 +3224,7 @@ exports.Class = Class = (function(superclass){
       f = curriedBoundFuncs[i$];
       ctor.body.lines.unshift(Assign(Chain(Literal('this')).add(Index(Key("_" + f.name))), Chain(Var(util('curry'))).add(Call([Chain(Var('prototype')).add(Index(f)), Var('true')]))), Assign(Chain(Literal('this')).add(Index(f)), Chain(Var(util('bind'))).add(Call([Literal('this'), Literal("'_" + f.name + "'")]))));
     }
-    lines.push(vname = fun.proto = Var(fun.bound = name));
+    lines.push(vname);
     args = [];
     if (that = this.sup) {
       args.push(that);
@@ -3268,8 +3269,8 @@ exports.Class = Class = (function(superclass){
 exports.Super = Super = (function(superclass){
   var prototype = extend$((import$(Super, superclass).displayName = 'Super', Super), superclass).prototype, constructor = Super;
   function Super(){}
-  prototype.isCallable = YES;
-  prototype.compile = function(o){
+  Super.prototype.isCallable = YES;
+  Super.prototype.compile = function(o){
     var scope, that, result, ref$;
     scope = o.scope;
     if (!this.sproto) {
@@ -3306,24 +3307,24 @@ exports.Parens = Parens = (function(superclass){
     this$.rb = rb;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['it'];
-  prototype.show = function(){
+  Parens.prototype.children = ['it'];
+  Parens.prototype.show = function(){
     return this.string && '""';
   };
   prototype.delegate(['isComplex', 'isCallable', 'isArray', 'isRegex'], function(it){
     return this.it[it]();
   });
-  prototype.isString = function(){
+  Parens.prototype.isString = function(){
     return this.string || this.it.isString();
   };
-  prototype.unparen = function(){
+  Parens.prototype.unparen = function(){
     if (this.keep) {
       return this;
     } else {
       return this.it.unparen();
     }
   };
-  prototype.compile = function(o, level){
+  Parens.prototype.compile = function(o, level){
     var it;
     level == null && (level = o.level);
     it = this.it;
@@ -3351,11 +3352,11 @@ exports.Splat = Splat = (function(superclass){
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
   ref$ = Parens.prototype, prototype.children = ref$.children, prototype.isComplex = ref$.isComplex;
-  prototype.isAssignable = YES;
-  prototype.assigns = function(it){
+  Splat.prototype.isAssignable = YES;
+  Splat.prototype.assigns = function(it){
     return this.it.assigns(it);
   };
-  prototype.compile = function(){
+  Splat.prototype.compile = function(){
     return this.carp('invalid splat');
   };
   Splat.compileArray = function(o, list, apply){
@@ -3425,13 +3426,13 @@ exports.Jump = Jump = (function(superclass){
     this.verb = verb;
     this.label = label;
   }
-  prototype.show = function(){
+  Jump.prototype.show = function(){
     var that;
     return (this.verb || '') + ((that = this.label) ? ' ' + that : '');
   };
-  prototype.isStatement = YES;
-  prototype.makeReturn = THIS;
-  prototype.getJump = function(ctx){
+  Jump.prototype.isStatement = YES;
+  Jump.prototype.makeReturn = THIS;
+  Jump.prototype.getJump = function(ctx){
     var that, ref$;
     ctx || (ctx = {});
     if (!ctx[this.verb]) {
@@ -3443,7 +3444,7 @@ exports.Jump = Jump = (function(superclass){
         : ctx.labels = []) && this;
     }
   };
-  prototype.compileNode = function(o){
+  Jump.prototype.compileNode = function(o){
     var that, ref$;
     if (that = this.label) {
       in$(that, (ref$ = o.labels) != null
@@ -3467,8 +3468,8 @@ exports.Throw = Throw = (function(superclass){
     this$.it = it;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.getJump = VOID;
-  prototype.compileNode = function(o){
+  Throw.prototype.getJump = VOID;
+  Throw.prototype.compileNode = function(o){
     var ref$;
     return sn(this, "throw ", ((ref$ = this.it) != null ? ref$.compile(o, LEVEL_PAREN) : void 8) || 'null', ";");
   };
@@ -3483,8 +3484,8 @@ exports.Return = Return = (function(superclass){
     }
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.getJump = THIS;
-  prototype.compileNode = function(o){
+  Return.prototype.getJump = THIS;
+  Return.prototype.compileNode = function(o){
     var that;
     return sn.apply(null, [this, "return"].concat(
       (that = this.it)
@@ -3505,14 +3506,14 @@ exports.While = While = (function(superclass){
       this.test = test;
     }
   }
-  prototype.children = ['test', 'body', 'update', 'else'];
-  prototype.aSource = 'test';
-  prototype.aTargets = ['body', 'update'];
-  prototype.show = function(){
+  While.prototype.children = ['test', 'body', 'update', 'else'];
+  While.prototype.aSource = 'test';
+  While.prototype.aTargets = ['body', 'update'];
+  While.prototype.show = function(){
     return [this.un ? '!' : void 8, this.post ? 'do' : void 8].join('');
   };
   prototype.isStatement = prototype.isArray = YES;
-  prototype.makeComprehension = function(toAdd, loops){
+  While.prototype.makeComprehension = function(toAdd, loops){
     this.isComprehension = true;
     while (loops.length) {
       toAdd = loops.pop().addBody(Block(toAdd));
@@ -3522,7 +3523,7 @@ exports.While = While = (function(superclass){
     }
     return this.addBody(Block(toAdd));
   };
-  prototype.getJump = function(ctx){
+  While.prototype.getJump = function(ctx){
     var i$, ref$, ref1$, len$, node;
     ctx || (ctx = {});
     ctx['continue'] = true;
@@ -3534,7 +3535,7 @@ exports.While = While = (function(superclass){
       }
     }
   };
-  prototype.addBody = function(body){
+  While.prototype.addBody = function(body){
     var top;
     this.body = body;
     if (this.guard) {
@@ -3546,15 +3547,15 @@ exports.While = While = (function(superclass){
     }
     return this;
   };
-  prototype.addGuard = function(guard){
+  While.prototype.addGuard = function(guard){
     this.guard = guard;
     return this;
   };
-  prototype.addObjComp = function(objComp){
+  While.prototype.addObjComp = function(objComp){
     this.objComp = objComp != null ? objComp : true;
     return this;
   };
-  prototype.makeReturn = function(it){
+  While.prototype.makeReturn = function(it){
     var last, ref$, ref1$, ref2$;
     if (this.hasReturned) {
       return this;
@@ -3585,7 +3586,7 @@ exports.While = While = (function(superclass){
     }
     return this;
   };
-  prototype.compileNode = function(o){
+  While.prototype.compileNode = function(o){
     var test, ref$, head, that;
     o.loop = true;
     this.test && (this.un
@@ -3611,7 +3612,7 @@ exports.While = While = (function(superclass){
     }
     return sn.apply(null, [null].concat(slice$.call(head), [sn(this, ') {'), this.compileBody((o.indent += TAB, o))]));
   };
-  prototype.compileBody = function(o){
+  While.prototype.compileBody = function(o){
     var lines, yet, tab, code, ret, mid, empty, _resultName, getResultName, last, hasLoop, res, temp, key$, ref$, bodyCode, this$ = this;
     o['break'] = o['continue'] = true;
     lines = this.body.lines, yet = this.yet, tab = this.tab;
@@ -3698,12 +3699,12 @@ exports.For = For = (function(superclass){
       this.carp('`for own` requires `of`');
     }
   }
-  prototype.children = ['item', 'source', 'from', 'to', 'step', 'body'];
-  prototype.aSource = null;
-  prototype.show = function(){
+  For.prototype.children = ['item', 'source', 'from', 'to', 'step', 'body'];
+  For.prototype.aSource = null;
+  For.prototype.show = function(){
     return ((this.kind || []).concat(this.index)).join(' ');
   };
-  prototype.addBody = function(body){
+  For.prototype.addBody = function(body){
     var hasYield, ref$, x$, that, this$ = this;
     hasYield = !!body.traverseChildren(function(child){
       if (child instanceof Yield) {
@@ -3738,7 +3739,7 @@ exports.For = For = (function(superclass){
     }
     return this;
   };
-  prototype.compileNode = function(o){
+  For.prototype.compileNode = function(o){
     var temps, idx, ref$, pvar, step, tvar, tail, fvar, vars, eq, cond, svar, srcPart, lvar, head, that, body;
     o.loop = true;
     temps = this.temps = [];
@@ -3844,11 +3845,11 @@ exports.For = For = (function(superclass){
 }(While));
 exports.StepSlice = StepSlice = (function(superclass){
   var prototype = extend$((import$(StepSlice, superclass).displayName = 'StepSlice', StepSlice), superclass).prototype, constructor = StepSlice;
-  prototype.makeReturn = function(makeReturnArg){
+  StepSlice.prototype.makeReturn = function(makeReturnArg){
     this.makeReturnArg = makeReturnArg;
     return superclass.prototype.makeReturn.apply(this, arguments);
   };
-  prototype.compileNode = function(o){
+  StepSlice.prototype.compileNode = function(o){
     var ref$, sub, ref, temps, code;
     this.index = o.scope.temporary('x');
     ref$ = this.target.unwrap().cache(o), sub = ref$[0], ref = ref$[1], temps = ref$[2];
@@ -3881,20 +3882,20 @@ exports.Try = Try = (function(superclass){
       ref$.lines.unshift(Assign(this.thrown || Var('e'), Var('e$')));
     }
   }
-  prototype.children = ['attempt', 'recovery', 'ensure'];
-  prototype.show = function(){
+  Try.prototype.children = ['attempt', 'recovery', 'ensure'];
+  Try.prototype.show = function(){
     return this.thrown;
   };
-  prototype.isStatement = YES;
-  prototype.isCallable = function(){
+  Try.prototype.isStatement = YES;
+  Try.prototype.isCallable = function(){
     var ref$;
     return ((ref$ = this.recovery) != null ? ref$.isCallable() : void 8) && this.attempt.isCallable();
   };
-  prototype.getJump = function(it){
+  Try.prototype.getJump = function(it){
     var ref$;
     return this.attempt.getJump(it) || ((ref$ = this.recovery) != null ? ref$.getJump(it) : void 8);
   };
-  prototype.makeReturn = function(){
+  Try.prototype.makeReturn = function(){
     var ref$;
     this.attempt = (ref$ = this.attempt).makeReturn.apply(ref$, arguments);
     if (this.recovery != null) {
@@ -3902,7 +3903,7 @@ exports.Try = Try = (function(superclass){
     }
     return this;
   };
-  prototype.compileNode = function(o){
+  Try.prototype.compileNode = function(o){
     var code, that;
     o.indent += TAB;
     code = [sn(this, 'try '), this.compileBlock(o, this.attempt)];
@@ -3942,14 +3943,14 @@ exports.Switch = Switch = (function(superclass){
       this['default'] = last.body;
     }
   }
-  prototype.children = ['topic', 'cases', 'default'];
-  prototype.aSource = 'topic';
-  prototype.aTargets = ['cases', 'default'];
-  prototype.show = function(){
+  Switch.prototype.children = ['topic', 'cases', 'default'];
+  Switch.prototype.aSource = 'topic';
+  Switch.prototype.aTargets = ['cases', 'default'];
+  Switch.prototype.show = function(){
     return this.type;
   };
-  prototype.isStatement = YES;
-  prototype.isCallable = function(){
+  Switch.prototype.isStatement = YES;
+  Switch.prototype.isCallable = function(){
     var i$, ref$, len$, c;
     for (i$ = 0, len$ = (ref$ = this.cases).length; i$ < len$; ++i$) {
       c = ref$[i$];
@@ -3963,7 +3964,7 @@ exports.Switch = Switch = (function(superclass){
       return true;
     }
   };
-  prototype.getJump = function(ctx){
+  Switch.prototype.getJump = function(ctx){
     var i$, ref$, len$, c, that;
     ctx || (ctx = {});
     ctx['break'] = true;
@@ -3975,7 +3976,7 @@ exports.Switch = Switch = (function(superclass){
     }
     return (ref$ = this['default']) != null ? ref$.getJump(ctx) : void 8;
   };
-  prototype.makeReturn = function(){
+  Switch.prototype.makeReturn = function(){
     var i$, ref$, len$, c;
     for (i$ = 0, len$ = (ref$ = this.cases).length; i$ < len$; ++i$) {
       c = ref$[i$];
@@ -3986,7 +3987,7 @@ exports.Switch = Switch = (function(superclass){
     }
     return this;
   };
-  prototype.compileNode = function(o){
+  Switch.prototype.compileNode = function(o){
     var tab, ref$, targetNode, target, topic, t, code, stop, i$, len$, i, c, that;
     tab = this.tab;
     if (this.target) {
@@ -4021,18 +4022,18 @@ exports.Case = Case = (function(superclass){
     this.tests = tests;
     this.body = body;
   }
-  prototype.children = ['tests', 'body'];
-  prototype.isCallable = function(){
+  Case.prototype.children = ['tests', 'body'];
+  Case.prototype.isCallable = function(){
     return this.body.isCallable();
   };
-  prototype.makeReturn = function(){
+  Case.prototype.makeReturn = function(){
     var ref$, ref1$;
     if (((ref$ = (ref1$ = this.body.lines)[ref1$.length - 1]) != null ? ref$.value : void 8) !== 'fallthrough') {
       (ref1$ = this.body).makeReturn.apply(ref1$, arguments);
     }
     return this;
   };
-  prototype.compileCase = function(o, tab, nobr, bool, type, target){
+  Case.prototype.compileCase = function(o, tab, nobr, bool, type, target){
     var tests, i$, ref$, len$, test, j$, ref1$, len1$, t, i, tar, binary, that, code, lines, last, ft, bodyCode;
     tests = [];
     for (i$ = 0, len$ = (ref$ = this.tests).length; i$ < len$; ++i$) {
@@ -4095,22 +4096,22 @@ exports.If = If = (function(superclass){
     this$.un = un;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['if', 'then', 'else'];
-  prototype.aSource = 'if';
-  prototype.aTargets = ['then'];
-  prototype.show = function(){
+  If.prototype.children = ['if', 'then', 'else'];
+  If.prototype.aSource = 'if';
+  If.prototype.aTargets = ['then'];
+  If.prototype.show = function(){
     return this.un && '!';
   };
-  prototype.terminator = '';
+  If.prototype.terminator = '';
   prototype.delegate(['isCallable', 'isArray', 'isString', 'isRegex'], function(it){
     var ref$;
     return ((ref$ = this['else']) != null ? ref$[it]() : void 8) && this.then[it]();
   });
-  prototype.getJump = function(it){
+  If.prototype.getJump = function(it){
     var ref$;
     return this.then.getJump(it) || ((ref$ = this['else']) != null ? ref$.getJump(it) : void 8);
   };
-  prototype.makeReturn = function(){
+  If.prototype.makeReturn = function(){
     var ref$;
     this.then = (ref$ = this.then).makeReturn.apply(ref$, arguments);
     if (this['else'] != null) {
@@ -4118,7 +4119,7 @@ exports.If = If = (function(superclass){
     }
     return this;
   };
-  prototype.compileNode = function(o){
+  If.prototype.compileNode = function(o){
     if (this.un) {
       this['if'] = this['if'].invert();
     } else {
@@ -4130,7 +4131,7 @@ exports.If = If = (function(superclass){
       return this.compileStatement(o);
     }
   };
-  prototype.compileStatement = function(o){
+  If.prototype.compileStatement = function(o){
     var code, els;
     code = [sn(this, "if (", this['if'].compile(o, LEVEL_PAREN), ") ")];
     o.indent += TAB;
@@ -4146,7 +4147,7 @@ exports.If = If = (function(superclass){
       ]
     ));
   };
-  prototype.compileExpression = function(o){
+  If.prototype.compileExpression = function(o){
     var thn, els, code, pad;
     thn = this.then, els = this['else'] || Literal('void');
     this['void'] && (thn['void'] = els['void'] = true);
@@ -4183,11 +4184,11 @@ exports.Label = Label = (function(superclass){
     }
   }
   ref$ = Parens.prototype, prototype.children = ref$.children, prototype.isCallable = ref$.isCallable, prototype.isArray = ref$.isArray;
-  prototype.show = function(){
+  Label.prototype.show = function(){
     return this.label;
   };
-  prototype.isStatement = YES;
-  prototype.getJump = function(ctx){
+  Label.prototype.isStatement = YES;
+  Label.prototype.getJump = function(ctx){
     var ref$;
     ctx || (ctx = {});
     ((ref$ = ctx.labels) != null
@@ -4195,12 +4196,12 @@ exports.Label = Label = (function(superclass){
       : ctx.labels = []).push(this.label);
     return this.it.getJump((ctx['break'] = true, ctx));
   };
-  prototype.makeReturn = function(){
+  Label.prototype.makeReturn = function(){
     var ref$;
     this.it = (ref$ = this.it).makeReturn.apply(ref$, arguments);
     return this;
   };
-  prototype.compileNode = function(o){
+  Label.prototype.compileNode = function(o){
     var label, it, labels;
     label = this.label, it = this.it;
     labels = o.labels = slice$.call(o.labels || []);
@@ -4224,22 +4225,22 @@ exports.Cascade = Cascade = (function(superclass){
     this$.prog1 = prog1;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.show = function(){
+  Cascade.prototype.show = function(){
     return this.prog1;
   };
-  prototype.children = ['input', 'output'];
-  prototype.terminator = '';
+  Cascade.prototype.children = ['input', 'output'];
+  Cascade.prototype.terminator = '';
   prototype.delegate(['isCallable', 'isArray', 'isString', 'isRegex'], function(it){
     return this[this.prog1 ? 'input' : 'output'][it]();
   });
-  prototype.getJump = function(it){
+  Cascade.prototype.getJump = function(it){
     return this.output.getJump(it);
   };
-  prototype.makeReturn = function(ret){
+  Cascade.prototype.makeReturn = function(ret){
     this.ret = ret;
     return this;
   };
-  prototype.compileNode = function(o){
+  Cascade.prototype.compileNode = function(o){
     var level, input, output, prog1, ref, ref$, code, out;
     level = o.level;
     input = this.input, output = this.output, prog1 = this.prog1, ref = this.ref;
@@ -4286,18 +4287,18 @@ exports.JS = JS = (function(superclass){
     this$.comment = comment;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.show = function(){
+  JS.prototype.show = function(){
     if (this.comment) {
       return this.code;
     } else {
       return "`" + this.code + "`";
     }
   };
-  prototype.terminator = '';
+  JS.prototype.terminator = '';
   prototype.isAssignable = prototype.isCallable = function(){
     return !this.comment;
   };
-  prototype.compile = function(it){
+  JS.prototype.compile = function(it){
     return sn(this, snSafe(this.literal
       ? entab(this.code, it.indent)
       : this.code));
@@ -4311,8 +4312,8 @@ exports.Require = Require = (function(superclass){
     this$.body = body;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['body'];
-  prototype.compile = function(o){
+  Require.prototype.children = ['body'];
+  Require.prototype.compile = function(o){
     var getValue, processItem, code, i$, ref$, len$, item, this$ = this;
     getValue = function(item, throwError){
       switch (false) {
@@ -4367,9 +4368,9 @@ exports.Util = Util = (function(superclass){
     this$.verb = verb;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.show = Jump.prototype.show;
-  prototype.isCallable = YES;
-  prototype.compile = function(){
+  Util.prototype.show = Jump.prototype.show;
+  Util.prototype.isCallable = YES;
+  Util.prototype.compile = function(){
     return sn(this, util(this.verb));
   };
   Util.Extends = function(){
@@ -4384,9 +4385,9 @@ exports.Vars = Vars = (function(superclass){
     this$.vars = vars;
     return this$;
   } function ctor$(){} ctor$.prototype = prototype;
-  prototype.children = ['vars'];
-  prototype.makeReturn = THIS;
-  prototype.compile = function(o, level){
+  Vars.prototype.children = ['vars'];
+  Vars.prototype.makeReturn = THIS;
+  Vars.prototype.compile = function(o, level){
     var i$, ref$, len$, v, value;
     for (i$ = 0, len$ = (ref$ = this.vars).length; i$ < len$; ++i$) {
       v = ref$[i$], value = v.value;

--- a/lib/mode-ls.js
+++ b/lib/mode-ls.js
@@ -12,7 +12,7 @@ define('ace/mode/ls', function(require, exports, module){
       }
     }
     indenter = RegExp('(?:[({[=:]|[-~]>|\\b(?:e(?:lse|xport)|d(?:o|efault)|t(?:ry|hen)|finally|import(?:\\s*all)?|const|var|let|new|catch(?:\\s*' + identifier + ')?))\\s*$');
-    prototype.getNextLineIndent = function(state, line, tab){
+    LiveScriptMode.prototype.getNextLineIndent = function(state, line, tab){
       var indent, tokens;
       indent = this.$getIndent(line);
       tokens = this.$tokenizer.getLineTokens(line, state).tokens;
@@ -23,7 +23,7 @@ define('ace/mode/ls', function(require, exports, module){
       }
       return indent;
     };
-    prototype.toggleCommentLines = function(state, doc, startRow, endRow){
+    LiveScriptMode.prototype.toggleCommentLines = function(state, doc, startRow, endRow){
       var comment, range, i$, i, out, line;
       comment = /^(\s*)#/;
       range = new (require('ace/range')).Range(0, 0, 0, 0);
@@ -40,11 +40,11 @@ define('ace/mode/ls', function(require, exports, module){
       }
       return 1 - out * 2;
     };
-    prototype.checkOutdent = function(state, line, input){
+    LiveScriptMode.prototype.checkOutdent = function(state, line, input){
       var ref$;
       return (ref$ = this.$outdent) != null ? ref$.checkOutdent(line, input) : void 8;
     };
-    prototype.autoOutdent = function(state, doc, row){
+    LiveScriptMode.prototype.autoOutdent = function(state, doc, row){
       var ref$;
       return (ref$ = this.$outdent) != null ? ref$.autoOutdent(doc, row) : void 8;
     };

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1761,7 +1761,7 @@ class exports.Import extends Node
     compile-assign: (o, items) ->
         return @left.compile o unless items.length
         top = not o.level
-        if items.length < 2 and (top or @void or items.0 instanceof Splat)
+        if @proto or (items.length < 2 and (top or @void or items.0 instanceof Splat))
             reft = @left
             reft = Parens reft if reft.is-complex!
         else [left, reft, @temps] = @left.cache o
@@ -1990,6 +1990,7 @@ class exports.Class extends Node
         name = decl or @name
         if ID.test name || '' then fun.cname = name else name = \constructor
         proto = Var \prototype
+        vname = fun.proto = Var fun.bound = name
         const ctor-name = \constructor$$
         var ctor, ctor-place
         import-proto-obj = (node, i) ->
@@ -2017,7 +2018,9 @@ class exports.Class extends Node
                     prop.val.class-bound = true
                 for v in [] ++ prop.val
                     v.meth = key
-            if node.items.length then Import proto, node else Literal 'void'
+            if node.items.length
+              Import(Chain vname .add Index Key \prototype; node) <<< {+proto}
+            else Literal 'void'
 
         for node, i in lines
             if node instanceof Obj
@@ -2057,7 +2060,7 @@ class exports.Class extends Node
                          .add Call [Literal \this; Literal "'_#{f.name}'"])
 
 
-        lines.push vname = fun.proto = Var fun.bound = name
+        lines.push vname
         args = []
         if @sup
             args.push that

--- a/test/compilation.ls
+++ b/test/compilation.ls
@@ -337,3 +337,20 @@ saveHere = {}
 LiveScript.compile 'x ?= 1', bare: true, saveScope: saveHere
 code = LiveScript.compile 'y ?= 2', bare: true, saveScope: saveHere
 ok 0 <= code.indexOf 'var x, y'
+
+# The presence of the full "ClassName.prototype.methodName =" in the compiled
+# code is relevant to post-processors like Google's Closure Compiler as a cue
+# that these are class methods.
+compiled = LiveScript.compile '''
+  class A
+    one: -> 1
+    two: -> 2
+  class B extends A
+    three: -> 3
+    four: -> 4
+'''
+for <[
+  A.prototype.one A.prototype.two
+  B.prototype.three B.prototype.four
+]>
+  ok compiled.indexOf(..) >= 0 "missing #{..}"


### PR DESCRIPTION
... when assigning members to prototypes. As of this writing, Google's
Closure Compiler can only perform some advanced analysis and
optimizations if this form is used instead of the runtime-equivalent
prototype var.

(See for yourself! Compare the optimizations that are applied to the [output of current lsc](http://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540compilation_level%2520ADVANCED_OPTIMIZATIONS%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250Avar%2520Foo%253B%250AFoo%2520%253D%2520%28function%28%29%257B%250A%2520%2520Foo.displayName%2520%253D%2520%27Foo%27%253B%250A%2520%2520var%2520prototype%2520%253D%2520Foo.prototype%252C%2520constructor%2520%253D%2520Foo%253B%250A%2520%2520prototype.stuff%2520%253D%2520function%28%29%257B%250A%2520%2520%2520%2520return%2520this.a%2520%252B%2520this.b%253B%250A%2520%2520%257D%253B%250A%2520%2520prototype.unused%2520%253D%2520function%28%29%257B%250A%2520%2520%2520%2520return%2520%27optimize%2520me%2520away%2520please%27%253B%250A%2520%2520%257D%253B%250A%2520%2520function%2520Foo%28a%252C%2520b%29%257B%250A%2520%2520%2520%2520this.a%2520%253D%2520a%253B%250A%2520%2520%2520%2520this.b%2520%253D%2520b%253B%250A%2520%2520%257D%250A%2520%2520return%2520Foo%253B%250A%257D%28%29%29%253B%250A%250Awindow%255B%27main%27%255D%2520%253D%2520function%2520%28%29%2520%257B%250A%2520%2520var%2520f%2520%253D%2520new%2520Foo%285%252C%252010%29%253B%250A%2520%2520console.log%28f.stuff%28%29%29%253B%250A%257D) with those applied to the [output of the patch](http://closure-compiler.appspot.com/home#code%3D%252F%252F%2520%253D%253DClosureCompiler%253D%253D%250A%252F%252F%2520%2540compilation_level%2520ADVANCED_OPTIMIZATIONS%250A%252F%252F%2520%2540output_file_name%2520default.js%250A%252F%252F%2520%253D%253D%252FClosureCompiler%253D%253D%250A%250Avar%2520Foo%253B%250AFoo%2520%253D%2520%28function%28%29%257B%250A%2520%2520Foo.displayName%2520%253D%2520%27Foo%27%253B%250A%2520%2520var%2520prototype%2520%253D%2520Foo.prototype%252C%2520constructor%2520%253D%2520Foo%253B%250A%2520%2520Foo.prototype.stuff%2520%253D%2520function%28%29%257B%250A%2520%2520%2520%2520return%2520this.a%2520%252B%2520this.b%253B%250A%2520%2520%257D%253B%250A%2520%2520Foo.prototype.unused%2520%253D%2520function%28%29%257B%250A%2520%2520%2520%2520return%2520%27optimize%2520me%2520away%2520please%27%253B%250A%2520%2520%257D%253B%250A%2520%2520function%2520Foo%28a%252C%2520b%29%257B%250A%2520%2520%2520%2520this.a%2520%253D%2520a%253B%250A%2520%2520%2520%2520this.b%2520%253D%2520b%253B%250A%2520%2520%257D%250A%2520%2520return%2520Foo%253B%250A%257D%28%29%29%253B%250A%250Awindow%255B%27main%27%255D%2520%253D%2520function%2520%28%29%2520%257B%250A%2520%2520var%2520f%2520%253D%2520new%2520Foo%285%252C%252010%29%253B%250A%2520%2520console.log%28f.stuff%28%29%29%253B%250A%257D). The `unused` method gets removed in the latter.)
