### PR TITLE
extend cascade comprehension to support `[.. for from i to j by k]`

### DIFF
--- a/src/ast.ls
+++ b/src/ast.ls
@@ -2348,6 +2348,7 @@ class exports.For extends While
             [pvar, step] = (@step or Literal 1)compile-loop-reference o, \step
             pvar is step or temps.push pvar
         if @from
+            @item = Var idx if @ref
             [tvar, tail] = @to.compile-loop-reference o, \to
             fvar = @from.compile o, LEVEL_LIST
             vars = "#idx = #fvar"
@@ -2397,7 +2398,7 @@ class exports.For extends While
         o.indent += TAB
         if @index and not @object
             head.push \\n + o.indent, Assign(Var @index; JS idx).compile(o, LEVEL_TOP), \;
-        if @item and not @item.is-empty!
+        if @item and not @item.is-empty! and not @from
             head.push \\n + o.indent, Assign(@item, JS "#svar[#idx]")compile(o, LEVEL_TOP), \;
         o.ref = @item.value if @ref
         body  = @compile-body o

--- a/src/grammar.ls
+++ b/src/grammar.ls
@@ -398,17 +398,23 @@ bnf =
         o 'FOR ID FROM Expression TO Expression'
         , -> new For kind: $1, index: $2, from: $4, op: $5, to: $6
         o 'FOR FROM Expression TO Expression'
-        , -> new For kind: $1,            from: $3, op: $4, to: $5
+        , -> new For kind: $1,            from: $3, op: $4, to: $5, ref: true
         o 'FOR ID FROM Expression TO Expression CASE Expression'
         , -> new For kind: $1, index: $2, from: $4, op: $5, to: $6, guard: $8
         o 'FOR FROM Expression TO Expression CASE Expression'
-        , -> new For kind: $1,            from: $3, op: $4, to: $5, guard: $7
+        , -> new For kind: $1,            from: $3, op: $4, to: $5, guard: $7, ref: true
         o 'FOR ID FROM Expression TO Expression BY Expression'
         , -> new For kind: $1, index: $2, from: $4, op: $5, to: $6, step: $8
+        o 'FOR FROM Expression TO Expression BY Expression'
+        , -> new For kind: $1,            from: $3, op: $4, to: $5, step: $6, ref: true
         o 'FOR ID FROM Expression TO Expression BY Expression CASE Expression'
         , -> new For kind: $1, index: $2, from: $4, op: $5, to: $6, step: $8, guard: $10
+        o 'FOR FROM Expression TO Expression BY Expression CASE Expression'
+        , -> new For kind: $1,            from: $3, op: $4, to: $5, step: $7, guard: $9, ref: true
         o 'FOR ID FROM Expression TO Expression CASE Expression BY Expression'
         , -> new For kind: $1, index: $2, from: $4, op: $5, to: $6, guard: $8, step: $10
+        o 'FOR FROM Expression TO Expression CASE Expression BY Expression'
+        , -> new For kind: $1,            from: $3, op: $4, to: $5, guard: $7, step: $9, ref: true
 
         o 'WHILE Expression'                 -> new While $2, $1 is 'until'
         o 'WHILE Expression CASE Expression' -> new While $2, $1 is 'until' .add-guard $4

--- a/test/loop.ls
+++ b/test/loop.ls
@@ -295,6 +295,7 @@ deep-equal [3,4,5] [.. + 2 for [1 2 3]]
 deep-equal [3,5]   [.. + 2 for [1 2 3] when .. % 2 isnt 0]
 deep-equal [5,4,3] [.. + 2 for [1 2 3] by -1]
 deep-equal [5,3]   [.. + 2 for [1 2 3] by -1 when .. % 2 isnt 0]
+deep-equal [5,3]   [.. + 2 for from 3 to 1 by -1 when .. % 2 isnt 0]
 
 list-of-obj =
   * ha: 1


### PR DESCRIPTION
This used to throw "stray ref" error.