### PR TITLE
Fix #858 Inconsistent empty splat assignment

### DIFF
--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1660,10 +1660,14 @@ class exports.Assign extends Node
                     continue if skip and i+2 is len
                     start = i+1
                     @temps = [ivar = o.scope.temporary \i]
-                    val = if skip then node = Var ivar; Var val else
-                        Arr.wrap JS "#i < (#ivar = #val)
-                                  \ ? #{ util \slice }.call(#rite, #i, #ivar)
-                                  \ : (#ivar = #i, [])"
+                    val = switch
+                    | skip
+                        Arr.wrap JS "#i < (#ivar = #val) ? #i : (#ivar = #i)"
+                    | _
+                        Arr.wrap JS do
+                            "#i < (#ivar = #val)
+                            \ ? #{ util \slice }.call(#rite, #i, #ivar)
+                            \ : (#ivar = #i, [])"
             else
                 (inc = ivar) and start < i and inc += " + #{ i - start }"
                 val = Chain rcache||=Literal(rite), [Index JS inc || i]

--- a/test/splat.ls
+++ b/test/splat.ls
@@ -102,6 +102,12 @@ eq b, 2
 eq a, 1
 eq b, 5
 
+# [LiveScript#858](https://github.com/gkz/LiveScript/issues/858)
+[a, ..., b, c, d] = [1 2 3]
+eq a, 1
+eq b, 2
+eq c, 3
+
 eq '''
 (function(){
   var a;


### PR DESCRIPTION
See #858

TL;DR: `[a, ..., b, c, d] = [1 2 3]` should behave the same as `[a, ...m, b, c, d]`