### PR TITLE
Fix for #923

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -1160,6 +1160,7 @@ exports.pair = function(it){
     return this.pair(it);
   }
   this.unline();
+  this.fclear();
   return this.closes.pop();
 };
 exports.able = function(call){
@@ -1205,6 +1206,9 @@ exports.fget = function(key){
 exports.fset = function(key, val){
   var ref$, key$;
   ((ref$ = this.flags)[key$ = this.closes.length] || (ref$[key$] = {}))[key] = val;
+};
+exports.fclear = function(){
+  this.flags.splice(this.closes.length);
 };
 exports.carp = function(it){
   carp(it, this.line);

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -840,6 +840,7 @@ exports <<<
             @dedent @dents[*-1]
             return @pair it
         @unline!
+        @fclear!
         @closes.pop!
 
     #### Helpers
@@ -886,6 +887,9 @@ exports <<<
 
     fset: (key, val) !->
         @flags{}[@closes.length][key] = val
+
+    fclear: !->
+        @flags.splice @closes.length
 
     # Throws a syntax error with the current line number.
     carp: !-> carp it, @line

--- a/test/compilation.ls
+++ b/test/compilation.ls
@@ -355,3 +355,20 @@ for <[
   B.prototype.three B.prototype.four
 ]>
   ok compiled.indexOf(..) >= 0 "missing #{..}"
+
+# [LiveScript#923](https://github.com/gkz/LiveScript/issues/923)
+# The lexer was keeping some state associated with the for comprehension past
+# its extent, which resulted in an incorrect lexing of the subsequent `in`
+# token. These don't comprehensively exercise the underlying flaw; they're
+# just regression checks for this specific report.
+LiveScript.compile '''
+[1 for a]
+[b in c]
+'''
+LiveScript.compile '''
+[[{b: {[.., 1] for a}}]]
+->
+  if c
+    d
+      .e (.f in [2 3])
+'''


### PR DESCRIPTION
This issue involved a lexer flag that was set in a for comprehension and
never cleared when the comprehension closed. The fix consists of
clearing all lexer flags at the current delimiter depth every time a
close delimiter is encountered. (It may be that this makes some
occurrences of `@fset _ false` elsewhere in the lexer redundant; to be
safe, I didn't attempt to remove any of them in this commit.)