### PR TITLE
Fix #926

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2933,7 +2933,7 @@ exports.Existence = Existence = (function(superclass){
   } function ctor$(){} ctor$.prototype = prototype;
   Existence.prototype.children = ['it'];
   Existence.prototype.compileNode = function(o){
-    var node, ref$, code, op, eq, anaphPre, anaphPost, that;
+    var node, ref$, code, op, eq, anaphPre, anaphPost;
     node = (ref$ = this.it.unwrap(), ref$.front = this.front, ref$);
     code = [node.compile(o, LEVEL_OP + PREC['=='])];
     if (node instanceof Var && !o.scope.check(code.join(""), true)) {
@@ -3981,9 +3981,8 @@ exports.Switch = Switch = (function(superclass){
     this['default'] = $default;
     if (type === 'match') {
       if (topic) {
-        this.target = Arr(topic);
+        this.topic = Arr(topic);
       }
-      this.topic = null;
     } else {
       if (topic) {
         if (topic.length > 1) {
@@ -4042,13 +4041,10 @@ exports.Switch = Switch = (function(superclass){
     return this;
   };
   Switch.prototype.compileNode = function(o){
-    var tab, ref$, targetNode, target, topic, t, code, stop, i$, len$, i, c, that;
+    var tab, topic, ref$, targetNode, target, t, code, stop, i$, len$, i, c, that;
     tab = this.tab;
-    if (this.target) {
-      ref$ = Chain(this.target).cacheReference(o), targetNode = ref$[0], target = ref$[1];
-    }
     topic = this.type === 'match'
-      ? (t = target
+      ? (this.topic && (ref$ = Chain(this.topic).cacheReference(o), targetNode = ref$[0], target = ref$[1]), t = target
         ? [targetNode]
         : [], Block(t.concat([Literal('false')])).compile(o, LEVEL_PAREN))
       : !!this.topic && this.anaphorize().compile(o, LEVEL_PAREN);

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -2536,8 +2536,7 @@ class exports.Try extends Node
 class exports.Switch extends Node
     (@type, @topic, @cases, @default) ->
         if type is \match
-            @target = Arr topic if topic
-            @topic = null
+            @topic = Arr topic if topic
         else
             if topic
                 throw "can't have more than one topic in switch statement" if topic.length > 1
@@ -2571,8 +2570,8 @@ class exports.Switch extends Node
 
     compile-node: (o) ->
         {tab} = this
-        [target-node, target] = Chain @target .cache-reference o if @target
         topic = if @type is \match
+            [target-node, target] = Chain @topic .cache-reference o if @topic
             t = if target then [target-node] else []
             Block (t ++ [Literal \false]) .compile o, LEVEL_PAREN
         else

--- a/test/switch.ls
+++ b/test/switch.ls
@@ -273,3 +273,15 @@ match 1, 3, 3
 | 1, 1, 2 or 3 => ok 0
 | 1, 2 or 3, 3 => ok 1
 | _            => ok 0
+
+
+# [LiveScript#926](https://github.com/gkz/LiveScript/issues/926)
+# `match` wasn't binding `this` correctly in expression position
+o =
+  bar: 42
+  run: ->
+    foo:
+      match @bar
+      | (== 42) => true
+
+ok o.run!foo


### PR DESCRIPTION
This issue was caused by a failure of `traverse-children` to enter the
topic of a `match` statement (it worked fine with `switch`). This in
turn was because the Switch AST node, when representing a match, stored
its thing-to-match in a member called `target` instead of `topic`, but
'target' was not included in its list of child fields ('topic' was).

I couldn't see any use in keeping two distinct `topic` and `target`
fields, since they're never both used in the same node and never
referenced from other classes, so the issue was fixed by unifying them.