### PR TITLE
Fix REPL break on improper errors

### DIFF
--- a/lib/repl.js
+++ b/lib/repl.js
@@ -206,9 +206,6 @@ function repl(o, stdin, stdout){
           replCtx._ = x;
         }
         pp(x);
-        if (typeof x === 'function') {
-          say(x);
-        }
       }
     } catch (e$) {
       e = e$;

--- a/lib/repl.js
+++ b/lib/repl.js
@@ -19,7 +19,7 @@ dasherizeVars = function(str){
   }
 };
 function repl(o, stdin, stdout){
-  var say, warn, die, p, pp, ppp, MAXHISTORYSIZE, historyFile, code, cont, rl, reset, _ttyWrite, prompt, that, vm, replCtx, server, ref$;
+  var say, warn, die, p, pp, ppp, MAXHISTORYSIZE, historyFile, code, cont, rl, reset, _ttyWrite, prompt, that, vm, replCtx, vmError, server, ref$;
   stdin == null && (stdin = process.stdin);
   stdout == null && (stdout = process.stdout);
   say = function(){
@@ -209,6 +209,13 @@ function repl(o, stdin, stdout){
       }
     } catch (e$) {
       e = e$;
+      vmError == null && (vmError = vm.runInNewContext('Error', replCtx));
+      if (!(e instanceof vmError)) {
+        if (typeof stdin.setRawMode === 'function') {
+          stdin.setRawMode(false);
+          stdin.setRawMode(true);
+        }
+      }
       say(e);
     }
     reset();

--- a/src/repl.ls
+++ b/src/repl.ls
@@ -58,6 +58,7 @@ dasherize-vars = (str) -> if /^[a-z]/ is str then dasherize str else str
     repl-ctx <<< global
     repl-ctx <<< {module, exports, require}
     repl-ctx <<< {LiveScript, path, fs, util, say, warn, die, p, pp, ppp}
+    var vm-error
     server = require 'repl' .REPLServer:: with
       context: repl-ctx
       commands: []
@@ -130,7 +131,19 @@ dasherize-vars = (str) -> if /^[a-z]/ is str then dasherize str else str
         x  = vm.run-in-new-context LiveScript.compile(code, ops), repl-ctx, 'repl'
         repl-ctx <<< {_:x} if x?
         pp  x
-    catch then say e
+    catch
+      vm-error ?:= vm.run-in-new-context 'Error' repl-ctx
+      unless e instanceof vm-error
+        # There's an odd little Node.js bug (I think it's a bug) where if code
+        # inside the child context throws something that isn't an Error or one
+        # of its subtypes, stdin gets all messed up and the REPL stops
+        # responding correctly to keypresses like up/down arrow. This fixes it,
+        # and I wish I had more of an explanation why than the old
+        # jiggle-it-until-it-works principle.
+        if typeof stdin.set-raw-mode is \function
+          stdin.set-raw-mode off
+          stdin.set-raw-mode on
+      say e
     reset!
   if stdin == process.stdin
     rl.on 'close' ->

--- a/src/repl.ls
+++ b/src/repl.ls
@@ -130,7 +130,6 @@ dasherize-vars = (str) -> if /^[a-z]/ is str then dasherize str else str
         x  = vm.run-in-new-context LiveScript.compile(code, ops), repl-ctx, 'repl'
         repl-ctx <<< {_:x} if x?
         pp  x
-        say x if typeof x is 'function'
     catch then say e
     reset!
   if stdin == process.stdin


### PR DESCRIPTION
This is an ugly hack, but it fixes the issue where the REPL will
sometimes stop responding to arrow keys after an error has been thrown
in user code. Turns out, this happens whenever a string (or anything
other than something with Error in its prototype hierarchy) is thrown.
The fix is to restore "raw mode" on the input TTY handle when this
situation is detected, by the time-honored method of turning it off and
on again.

There's also a (basically) one-line commit in here that cleans up a double [Function] message that has been hanging around since Coco.

Close #733