### PR TITLE
Add test cases and fix implicit it in object shorthands (#899)

### DIFF
--- a/src/ast.ls
+++ b/src/ast.ls
@@ -294,6 +294,7 @@ SourceNode::to-string = (...args) ->
     unparen       : THIS
     unwrap        : THIS
     maybe-key     : THIS
+    maybe-var     : THIS
     expand-slice  : THIS
     var-name      : String
     get-accessors : VOID
@@ -567,6 +568,8 @@ class exports.Key extends Node
     is-complex: NO
 
     assigns: -> it is @name
+
+    maybe-var: -> (Var @name) <<< {@line}
 
     var-name: ->
         {name} = this

--- a/src/grammar.ls
+++ b/src/grammar.ls
@@ -341,9 +341,9 @@ bnf =
 
     # The various forms of property.
     KeyValue:
-        o 'Key'
+        o 'Key' -> $1.maybe-var!
         o 'LITERAL' -> Prop L(1,Key $1, $1 not in <[ arguments eval ]>), L 1 Literal $1
-        o 'Key     DOT KeyBase' -> Prop $3, Chain(            $1; [L 2 3 Index $3, $2])
+        o 'Key     DOT KeyBase' -> Prop $3, Chain( $1.maybe-var!; [L 2 3 Index $3, $2])
         o 'LITERAL DOT KeyBase' -> Prop $3, Chain(L 1 Literal $1; [L 2 3 Index $3, $2])
         o '{ Properties OptComma } LABEL' -> Prop L(5, Key $5), L(1, 4, Obj $2 .named $5)
         o '[ ArgList    OptComma ] LABEL' -> Prop L(5, Key $5), L(1, 4, Arr $2 .named $5)

--- a/test/function.ls
+++ b/test/function.ls
@@ -244,7 +244,7 @@ eq '''
 });
 ''', LiveScript.compile '-> @it', {+bare,-header}
 
-# Object shorthand `{it}` is `it`
+#899 Object shorthand `{it}` is `it`
 eq '''
 (function(it){
   return {
@@ -252,6 +252,13 @@ eq '''
   };
 });
 ''', LiveScript.compile '-> {it}', {+bare,-header}
+
+eq '''(function(it){
+  return {
+    it: it != null ? it : 'default'
+  };
+});
+''', LiveScript.compile '-> {it=\\default}', {+bare,-header}
 
 # Simple functions require no parens when comma-listed.
 funs = [->, -> 1, -> it, -> this, null]

--- a/test/function.ls
+++ b/test/function.ls
@@ -244,6 +244,14 @@ eq '''
 });
 ''', LiveScript.compile '-> @it', {+bare,-header}
 
+# Object shorthand `{it}` is `it`
+eq '''
+(function(it){
+  return {
+    it: it
+  };
+});
+''', LiveScript.compile '-> {it}', {+bare,-header}
 
 # Simple functions require no parens when comma-listed.
 funs = [->, -> 1, -> it, -> this, null]

--- a/test/if.ls
+++ b/test/if.ls
@@ -146,6 +146,16 @@ if 1
 that if 6?
 ''', {+bare,-header}
 
+# Object shorthand `that`
+eq '''
+var that;
+if (that = result) {
+  ({
+    that: that
+  });
+}
+''', LiveScript.compile '{that} if result', {+bare,-header}
+
 # Soaks should not `that`-aware.
 a = [0 1]
 if 1


### PR DESCRIPTION
The issue is cause by generating wrong AST node type when expanding object shorthands.

`{it.something}` is correctly expanded to `{something: it.something}`, but node type of `it` is still `Key`, and doesn't count when finding implicit `it` or `that`.

`something: it.something` parses to:
```
  Obj
    Prop
      Key something
      Chain
        Var it
        Index .
          Key something
```

`{it.something}` should do the same, but it parses to:
```
  Obj
    Prop
      Key something
      Chain
        Key it
        Index .
          Key something
```
Changes are made to convert node type to `Var` when expanding object shorthands, so that generated AST is consistent.