### PR TITLE
fix bug in anaphorization logic

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2938,15 +2938,17 @@ exports.Existence = Existence = (function(superclass){
   } function ctor$(){} ctor$.prototype = prototype;
   Existence.prototype.children = ['it'];
   Existence.prototype.compileNode = function(o){
-    var node, ref$, code, op, eq, anaphPre, anaphPost;
+    var node, ref$, code, op, eq, anaphPre, anaphPost, that;
     node = (ref$ = this.it.unwrap(), ref$.front = this.front, ref$);
     code = [node.compile(o, LEVEL_OP + PREC['=='])];
+    if (this.doAnaphorize) {
+      o.scope.declare('that', Var('that'));
+    }
     if (node instanceof Var && !o.scope.check(code.join(""), true)) {
       ref$ = this.negated
         ? ['||', '=']
         : ['&&', '!'], op = ref$[0], eq = ref$[1];
       if (this.doAnaphorize) {
-        o.scope.declare('that', Var('that'));
         ref$ = this.negated
           ? [["(that = undefined) || "], []]
           : [[], [" && (that = "].concat(slice$.call(code), [", true)"])], anaphPre = ref$[0], anaphPost = ref$[1];

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1863,10 +1863,11 @@ class exports.Existence extends Node implements Negatable
     compile-node: (o) ->
         node = @it.unwrap! <<< {@front}
         code = [(node.compile o, LEVEL_OP + PREC\==)]
+        if @do-anaphorize
+            o.scope.declare \that Var \that
         if node instanceof Var and not o.scope.check code.join(""), true
             [op, eq] = if @negated then <[ || = ]> else <[ && ! ]>
             if @do-anaphorize
-                o.scope.declare 'that' Var \that
                 [anaph-pre, anaph-post] = if @negated
                     then [["(that = undefined) || "], []]
                     else [[], [" && (that = ", ...code, ", true)"]]

--- a/test/existence.ls
+++ b/test/existence.ls
@@ -266,3 +266,6 @@ val = do ->
     while existent? and i--
         that
 eq val.join(' '), '5 4 3 2 1'
+
+# Ensure `var that` is declared even if the tested variable exists
+eq 'var a, that, b;\na = 0;\nif ((that = a) != null) {\n  b = that;\n}', LiveScript.compile 'a = 0; b = that if a?' {+bare,-header}


### PR DESCRIPTION
Recent work in the anaphorization logic sometimes caused the automatic
`that` variable to be used but not declared in its scope.

CC @misterfish, who did the original work in #895, in case I stepped on something he intended.