### PR TITLE
invert sense of ? with compound assignment

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2600,13 +2600,17 @@ exports.Assign = Assign = (function(superclass){
     return sn.apply(null, [null].concat(arrayFrom$(code)));
   };
   Assign.prototype.compileConditional = function(o, left){
-    var lefts, morph;
-    if (left instanceof Var && in$(this.logic, ['?']) && this.op === '=') {
+    var ref$, lcache, morph;
+    if (left instanceof Var && this.logic === '?' && this.op === '=') {
       o.scope.declare(left.value, left);
     }
-    lefts = Chain(left).cacheReference(o);
+    ref$ = Chain(left).cacheReference(o), lcache = ref$[0], left = ref$[1];
     o.level += LEVEL_OP < o.level;
-    morph = Binary(this.logic, lefts[0], (this.logic = false, this.left = lefts[1], this));
+    if (this.logic === '?' && ((ref$ = this.op) !== '=' && ref$ !== ':=')) {
+      this.logic = '&&';
+      lcache = Existence(lcache);
+    }
+    morph = Binary(this.logic, lcache, (this.logic = false, this.left = left, this));
     return sn(this, (morph['void'] = this['void'], morph).compileNode(o));
   };
   Assign.prototype.compileMinMax = function(o, left, right){

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1639,12 +1639,15 @@ class exports.Assign extends Node
         sn(null, ...code)
 
     compileConditional: (o, left) ->
-        if left instanceof Var and @logic in <[ ? ]> and @op is \=
+        if left instanceof Var and @logic is \? and @op is \=
             o.scope.declare left.value, left
-        lefts = Chain(left)cache-reference o
+        [lcache, left] = Chain(left)cache-reference o
         # Deal with `a && b ||= c`.
         o.level += LEVEL_OP < o.level
-        morph = Binary @logic, lefts.0, @<<<{-logic, left: lefts.1}
+        if @logic is \? and @op not in <[ = := ]>
+            @logic = \&&
+            lcache |>= Existence
+        morph = Binary @logic, lcache, @<<<{-logic, left}
         sn(this, (morph <<< {@void})compile-node o)
 
     compileMinMax: (o, left, right) ->

--- a/test/assignment.ls
+++ b/test/assignment.ls
@@ -110,6 +110,29 @@ eq i, 1
 {}p++
 ok 'LHS should take care frontness'
 
+# Compound assign with logic
+new
+  @a = 2
+  @a &&+= 10
+  eq 12 @a
+
+  @a = 0
+  @a &&+= 10
+  eq 0 @a
+
+  @a ?+= 5
+  eq 5 @a
+
+  @b ?+= 5
+  ok \b not of this
+
+  neg = -> -it
+  @a ?|>= neg
+  eq -5 @a
+
+  @b ?|>= neg
+  ok \b not of this
+
 
 ### Destructuring
 


### PR DESCRIPTION
The code `a ?= b` is basically `a? || a = b`, which is all well and good; it makes sense to want to assign to `a` if it's nullish.

However, prior to this commit, the code `a ?+= b` was basically `a? || a += b`, which is useless. If `a` is nullish, I certainly don't want to add anything to it.

Contrast with accessignment, where `a?=b` is basically `a? && a.=b`. Obviously better this way.

This commit makes `a ?_= b` mean `a? && a _= b`, as with accessignment, for any compound assignment operator. (`a ?= b` and `a ?:= b` are unchanged.)

Technically a breaking change, but I don't see how the feature would have been put to any good use before, so I'm treating this as a minor bug fix and waiting **one week** before merging on **June 26**, unless, as always, there are objections.