### PR TITLE
optimize `x in [0]`, `x in []`

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2964,13 +2964,24 @@ exports.In = In = (function(superclass){
   }
   In.prototype.children = ['item', 'array'];
   In.prototype.compileNode = function(o){
-    var array, items, code, ref$, sub, ref, cmp, cnj, i$, len$, i, test;
+    var array, items, value, code, ref$, sub, ref, cmp, cnj, i$, len$, i, test;
     items = (array = this.array).items;
-    if (!(array instanceof Arr) || items.length < 2) {
+    if (!(array instanceof Arr)) {
       return sn(this, this.negated ? '!' : '', util('in'), "(", this.item.compile(o, LEVEL_LIST), ", ", array.compile(o, LEVEL_LIST), ")");
     }
+    if (items.length === 0) {
+      if (!o.noWarn) {
+        this.warn("value can never be `in` an empty array");
+      }
+      value = !!this.negated + "";
+      return this.item.isComplex()
+        ? sn(this, "(", this.item.compile(o, LEVEL_LIST), ", ", value, ")")
+        : sn(this, value);
+    }
     code = [];
-    ref$ = this.item.cache(o, false, LEVEL_PAREN), sub = ref$[0], ref = ref$[1];
+    ref$ = items.length === 1
+      ? [ref$ = this.item.compile(o, LEVEL_PAREN), ref$]
+      : this.item.cache(o, false, LEVEL_PAREN), sub = ref$[0], ref = ref$[1];
     ref$ = this.negated
       ? [' !== ', ' && ']
       : [' === ', ' || '], cmp = ref$[0], cnj = ref$[1];
@@ -2992,7 +3003,7 @@ exports.In = In = (function(superclass){
       }
     }
     sub === ref || o.scope.free(ref);
-    if (o.level < LEVEL_OP + PREC['||']) {
+    if (o.level < LEVEL_OP + PREC[items.length === 1 ? '===' : '||']) {
       return sn.apply(null, [this].concat(arrayFrom$(code)));
     } else {
       return sn.apply(null, [this, "("].concat(arrayFrom$(code), [")"]));

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -1039,7 +1039,7 @@ exports.interpolate = function(str, idx, end){
       return parts.size = pos + i + end.length * 2, parts;
     case '#':
       c1 = str.charAt(i + 1);
-      id = in$(c1, ['@']) && c1 || (ID.lastIndex = i + 1, ID).exec(str)[1];
+      id = c1 === '@' && c1 || (ID.lastIndex = i + 1, ID).exec(str)[1];
       if (!(id || c1 === '{')) {
         continue;
       }
@@ -1059,7 +1059,7 @@ exports.interpolate = function(str, idx, end){
       if (id === '@') {
         id = 'this';
       }
-      if (in$(id, ['this'])) {
+      if (id === 'this') {
         tag = 'LITERAL';
       } else {
         id = camelize(id);

--- a/test/operator.ls
+++ b/test/operator.ls
@@ -88,6 +88,15 @@ a = [1 2 3]
 ok not ("2" in a)
 ok not ("2" in [1 2 3])
 
+# [LiveScript#986](https://github.com/gkz/LiveScript/issues/986)
+# Optimize `in` for one- and zero-element array literals
+eq "x() === 0;"    LiveScript.compile 'x! in [0]'     {+bare,-header}
+eq "x() !== 0;"    LiveScript.compile 'x! not in [0]' {+bare,-header}
+eq "(x(), false);" LiveScript.compile 'x! in [ ]'     {+bare,-header,+no-warn}
+eq "(x(), true);"  LiveScript.compile 'x! not in [ ]' {+bare,-header,+no-warn}
+eq "false;"        LiveScript.compile 'x in [ ]'      {+bare,-header,+no-warn}
+eq "true;"         LiveScript.compile 'x not in [ ]'  {+bare,-header,+no-warn}
+
 # Non-spaced values still work.
 x = 10
 y = -5


### PR DESCRIPTION
This applies the same optimization in use for `x in [0 1]` to one- and zero-element array literals.

Fix gkz/LiveScript#986.

---

This is a small optimization, so I'm setting the comment period for this at **one week** (plus change, to account for Thanksgiving weekend), after which I will merge on **Nov 27** if nobody has any concerns.