### PR TITLE
Fix flag combinations: -ce and -aj, fixes #993

### DIFF
--- a/lib/command.js
+++ b/lib/command.js
@@ -74,7 +74,7 @@ version = LiveScript.VERSION;
       if (positional.length && (o.json || /\.json$/.test(positional[0]))) {
         o.json = true;
         fshoot('readFile', positional[0], jsonCallback);
-      } else if (o.json) {
+      } else if (o.json && !o.ast) {
         getStdin(jsonCallback);
       } else {
         compileScript('', o.eval);
@@ -173,7 +173,7 @@ version = LiveScript.VERSION;
         throw null;
       }
       json = o.json || /\.json\.ls$/.test(filename);
-      run = o.run || o.eval;
+      run = o.run || json;
       if (run) {
         LiveScript.emit('compile', t);
         print = json || o.print;

--- a/src/command.ls
+++ b/src/command.ls
@@ -52,7 +52,7 @@ switch
       if positional.length and (o.json or /\.json$/.test positional.0)
           o.json = true
           fshoot 'readFile', positional.0, json-callback
-      else if o.json
+      else if o.json and not o.ast
           get-stdin json-callback
       else
           compile-script '' o.eval
@@ -119,7 +119,7 @@ switch
       throw
 
     json = o.json or /\.json\.ls$/.test filename
-    run = o.run or o.eval
+    run = o.run or json
     if run
       LiveScript.emit 'compile' t
       print = json or o.print


### PR DESCRIPTION
So these work again:

```
$ ./bin/lsc -m none -bce 'a!'
// Generated by LiveScript 1.5.0
a();
$ ./bin/lsc -aje '1'
{
  ...
}
```