### PR TITLE
RFC: support compiler warnings in a less ad-hoc way

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -388,9 +388,17 @@ SourceNode::to-string = (...args) ->
   },
   carp: function(msg, type){
     type == null && (type = SyntaxError);
-    throw type(msg + " on line " + (this.line || this.traverseChildren(function(it){
+    throw type(msg + " " + this.lineMsg());
+  },
+  warn: function(msg){
+    if (typeof console != 'undefined' && console !== null) {
+      console.warn("WARNING: " + msg + " " + this.lineMsg());
+    }
+  },
+  lineMsg: function(){
+    return "on line " + (this.line || this.traverseChildren(function(it){
       return it.line;
-    })));
+    }));
   },
   delegate: function(names, fn){
     var i$, len$;
@@ -2271,8 +2279,8 @@ exports.Binary = Binary = (function(superclass){
           return this.compileRegexEquals(o, that);
         }
         if (this.op === '===' && (this.first instanceof Literal && this.second instanceof Literal) && this.first.isWhat() !== this.second.isWhat()) {
-          if (typeof console != 'undefined' && console !== null) {
-            console.warn("WARNING: strict comparison of two different types will always be false: " + this.first.value + " == " + this.second.value);
+          if (!o.noWarn) {
+            this.warn("strict comparison of two different types will always be false: " + this.first.value + " == " + this.second.value);
           }
         }
       }

--- a/lib/command.js
+++ b/lib/command.js
@@ -149,7 +149,8 @@ version = LiveScript.VERSION;
       bare: o.bare,
       'const': o['const'],
       map: o.map,
-      header: o.header
+      header: o.header,
+      noWarn: o.noWarn
     };
     t = {
       input: input,

--- a/lib/options.js
+++ b/lib/options.js
@@ -113,6 +113,10 @@ module.exports = optionator({
       alias: 'm',
       type: 'String',
       description: "generate source maps - either: 'none', 'linked', 'linked-src', 'embedded', or 'debug'"
+    }, {
+      option: 'no-warn',
+      type: 'Boolean',
+      description: 'suppress compiler warnings'
     }
   ]
 });

--- a/scripts/test
+++ b/scripts/test
@@ -180,7 +180,7 @@
 
     try {
       console.log(filename);
-      LiveScript.run(code, { filename: filename, map: 'embedded' });
+      LiveScript.run(code, { filename: filename, map: 'embedded', noWarn: true });
     } catch (e) {
       ++failedTests;
 
@@ -205,7 +205,8 @@
         row = ref[1];
         col = ref[2];
         code = LiveScript.compile(code, {
-          bare: true
+          bare: true,
+          noWarn: true
         });
       }
 

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -259,8 +259,11 @@ SourceNode::to-string = (...args) ->
         @[@a-source] <<< {+cond}
 
     # Throws a syntax error, appending `@line` number to the message.
-    carp: (msg, type = SyntaxError) ->
-        throw type "#msg on line #{ @line or @traverse-children -> it.line }"
+    carp: (msg, type = SyntaxError) !-> throw type "#msg #{@line-msg!}"
+
+    warn: (msg) !-> console?warn "WARNING: #msg #{@line-msg!}"
+
+    line-msg: -> "on line #{ @line or @traverse-children -> it.line }"
 
     # Defines delegators.
     delegate: !(names, fn) ->
@@ -1404,7 +1407,7 @@ class exports.Binary extends Node
                     return @compileRegexEquals o, that
                 if @op is \=== and (@first instanceof Literal and @second instanceof Literal)
                 and @first.is-what! isnt @second.is-what!
-                    console?.warn "WARNING: strict comparison of two different types will always be false: #{@first.value} == #{@second.value}"
+                    @warn "strict comparison of two different types will always be false: #{@first.value} == #{@second.value}" unless o.no-warn
             return @compileChain o if COMPARER.test @op and COMPARER.test @second.op
         @first <<< {@front}
         code = [(@first .compile o, level = LEVEL_OP + PREC[@op]), " ", (@mapOp @op), " ", (@second.compile o, level)]

--- a/src/command.ls
+++ b/src/command.ls
@@ -103,6 +103,7 @@ switch
       o.const
       o.map
       o.header
+      o.no-warn
   }
   t       = {input, options}
   try

--- a/src/options.ls
+++ b/src/options.ls
@@ -97,3 +97,6 @@ module.exports = optionator do
           alias: 'm'
           type: 'String'
           description: "generate source maps - either: 'none', 'linked', 'linked-src', 'embedded', or 'debug'"
+        * option: 'no-warn'
+          type: 'Boolean'
+          description: 'suppress compiler warnings'


### PR DESCRIPTION
Since #987 got blocked on a compiler warning, but I wanted to write tests that would trigger that warning, I decided we should make compiler warnings more of a thing, largely so they could be disabled in tests (or other situations where they need to be disabled).

This of course opens the gates to more compiler warnings being used in more places where we want to eventually break compatibility or ensure that dumb things don't happen (see: #1000).

However, even though this is a small amount of code, it's adding a compiler flag which I think of as a big change. Want to get lots of feedback on this before I merge it.