### PR TITLE
Fixes #1009 Reset lexer before tokenization

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -19,6 +19,7 @@ exports.rewrite = function(it){
 };
 exports.tokenize = function(code, o){
   var i, prevIndex, c, charsConsumed, that;
+  this.reset();
   this.inter || (code = code.replace(/[\r\u2028\u2029\uFEFF]/g, ''));
   code = '\n' + code;
   this.tokens = [this.last = ['NEWLINE', '\n', 0, 0]];
@@ -104,6 +105,10 @@ exports.tokenize = function(code, o){
 };
 exports.dent = 0;
 exports.identifiers = {};
+exports.reset = function(){
+  this.dent = 0;
+  this.identifiers = {};
+};
 exports.hasOwn = Object.prototype.hasOwnProperty;
 exports.checkConsistency = function(camel, id){
   if (this.hasOwn.call(this.identifiers, camel) && this.identifiers[camel] !== id) {

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -19,8 +19,9 @@ exports.rewrite = function(it){
 };
 exports.tokenize = function(code, o){
   var i, prevIndex, c, charsConsumed, that;
-  this.dent = 0;
-  this.identifiers = {};
+  if (this.autoreset) {
+    this.reset();
+  }
   this.inter || (code = code.replace(/[\r\u2028\u2029\uFEFF]/g, ''));
   code = '\n' + code;
   this.tokens = [this.last = ['NEWLINE', '\n', 0, 0]];
@@ -103,6 +104,13 @@ exports.tokenize = function(code, o){
   }
   o.raw || this.rewrite();
   return this.tokens;
+};
+exports.dent = 0;
+exports.identifiers = {};
+exports.autoreset = false;
+exports.reset = function(){
+  this.dent = 0;
+  this.identifiers = {};
 };
 exports.hasOwn = Object.prototype.hasOwnProperty;
 exports.checkConsistency = function(camel, id){

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -19,7 +19,8 @@ exports.rewrite = function(it){
 };
 exports.tokenize = function(code, o){
   var i, prevIndex, c, charsConsumed, that;
-  this.reset();
+  this.dent = 0;
+  this.identifiers = {};
   this.inter || (code = code.replace(/[\r\u2028\u2029\uFEFF]/g, ''));
   code = '\n' + code;
   this.tokens = [this.last = ['NEWLINE', '\n', 0, 0]];
@@ -102,12 +103,6 @@ exports.tokenize = function(code, o){
   }
   o.raw || this.rewrite();
   return this.tokens;
-};
-exports.dent = 0;
-exports.identifiers = {};
-exports.reset = function(){
-  this.dent = 0;
-  this.identifiers = {};
 };
 exports.hasOwn = Object.prototype.hasOwnProperty;
 exports.checkConsistency = function(camel, id){

--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -19,9 +19,6 @@ exports.rewrite = function(it){
 };
 exports.tokenize = function(code, o){
   var i, prevIndex, c, charsConsumed, that;
-  if (this.autoreset) {
-    this.reset();
-  }
   this.inter || (code = code.replace(/[\r\u2028\u2029\uFEFF]/g, ''));
   code = '\n' + code;
   this.tokens = [this.last = ['NEWLINE', '\n', 0, 0]];
@@ -107,7 +104,6 @@ exports.tokenize = function(code, o){
 };
 exports.dent = 0;
 exports.identifiers = {};
-exports.autoreset = false;
 exports.reset = function(){
   this.dent = 0;
   this.identifiers = {};

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -39,7 +39,6 @@ exports <<<
     #### Main Loop
 
     tokenize: (code, o) ->
-        @reset! if @autoreset
         @inter or code.=replace /[\r\u2028\u2029\uFEFF]/g ''
         # Prepend a newline to handle leading INDENT.
         code = '\n' + code
@@ -111,10 +110,10 @@ exports <<<
     # Map of all Identifiers
     identifiers: {}
 
-    # Reset before tokenization or not
-    autoreset: false
-
-    reset: !-> @ <<< dent:0 identifiers: {}
+    # Resets state of lexer
+    # Design to be called by external system that needs to reuse lexer
+    # e.g. editor plugin checking multiple livescript files for errors
+    reset: !-> this <<< dent:0 identifiers: {}
 
     has-own: Object.prototype.has-own-property
 

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -39,6 +39,7 @@ exports <<<
     #### Main Loop
 
     tokenize: (code, o) ->
+        @reset!
         @inter or code.=replace /[\r\u2028\u2029\uFEFF]/g ''
         # Prepend a newline to handle leading INDENT.
         code = '\n' + code
@@ -109,6 +110,8 @@ exports <<<
 
     # Map of all Identifiers
     identifiers: {}
+
+    reset: !-> @ <<< dent:0 identifiers: {}
 
     has-own: Object.prototype.has-own-property
 

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -39,7 +39,10 @@ exports <<<
     #### Main Loop
 
     tokenize: (code, o) ->
-        @reset!
+        # The current indentation level.
+        @dent = 0
+        # Map of all Identifiers
+        @identifiers = {}
         @inter or code.=replace /[\r\u2028\u2029\uFEFF]/g ''
         # Prepend a newline to handle leading INDENT.
         code = '\n' + code
@@ -104,14 +107,6 @@ exports <<<
         o.raw or @rewrite!
 
         @tokens
-
-    # The current indentation level.
-    dent: 0
-
-    # Map of all Identifiers
-    identifiers: {}
-
-    reset: !-> @ <<< dent:0 identifiers: {}
 
     has-own: Object.prototype.has-own-property
 

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -39,10 +39,7 @@ exports <<<
     #### Main Loop
 
     tokenize: (code, o) ->
-        # The current indentation level.
-        @dent = 0
-        # Map of all Identifiers
-        @identifiers = {}
+        @reset! if @autoreset
         @inter or code.=replace /[\r\u2028\u2029\uFEFF]/g ''
         # Prepend a newline to handle leading INDENT.
         code = '\n' + code
@@ -107,6 +104,17 @@ exports <<<
         o.raw or @rewrite!
 
         @tokens
+
+    # The current indentation level.
+    dent: 0
+
+    # Map of all Identifiers
+    identifiers: {}
+
+    # Reset before tokenization or not
+    autoreset: false
+
+    reset: !-> @ <<< dent:0 identifiers: {}
 
     has-own: Object.prototype.has-own-property
 


### PR DESCRIPTION
Fix for #1009 moved initialization of lexers property `identifiers` and `dend` inside `tokenize` method to ensure that whenever lexer is used multiple times in a row, it starts with fresh state.