### PR TITLE
fix gkz/LiveScript#1027

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -3513,6 +3513,12 @@ exports.Parens = Parens = (function(superclass){
     this.it = val.unparen();
     return Parens(key);
   };
+  Parens.prototype.rewriteShorthand = function(o){
+    var that;
+    if (that = this.it.rewriteShorthand(o)) {
+      this.it = that;
+    }
+  };
   return Parens;
 }(Node));
 exports.Splat = Splat = (function(superclass){

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -2247,6 +2247,11 @@ class exports.Parens extends Node
         @it = val.unparen!
         Parens key
 
+    rewrite-shorthand: (o) !->
+        # Intentionally not passing the second argument to rewrite-shorthand.
+        # The contents of Parens are never in assign position.
+        @it = that if @it.rewrite-shorthand o
+
 #### Splat
 # A splat, either as an argument to a call,
 # the operand of a unary operator to be spread,

--- a/test/assignment.ls
+++ b/test/assignment.ls
@@ -510,3 +510,14 @@ eq 2 changeMe
 compileThrows 'cannot assign to reserved word \'match\'' 1 '''
   match = 1
 '''
+
+# [LiveScript#1027](https://github.com/gkz/LiveScript/issues/1027)
+a = [9 9]
+i = 0
+a[i = 1] = 2
+eq ''+a, '9,2'
+eq i, 1
+
+a[i += 1] = 3
+eq ''+a, '9,2,3'
+eq i, 2


### PR DESCRIPTION
This fix depends on the implicit parentheses that get added to the key
expression in `a[i = 1] = 2`. There may be other AST nodes that are
currently transparent to whether they are in assign position that
shouldn't be.

Fixes #1027.

---

This is a simple bug fix (and an important one, as it's a regression from 1.5), so I intend to merge in **one week** on or after **April 4**.