### PR TITLE
lexer: handle words literals with more care

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -586,7 +586,7 @@ exports.doLine = function(code, index){
     this.newline();
   } else {
     tag = last[0], val = last[1];
-    if (tag === 'ASSIGN' && ((ref$ = val + '') !== '=' && ref$ !== ':=' && ref$ !== '+=') || val === '++' && (ref$ = this.tokens)[ref$.length - 2].spaced || (tag === '+-' || tag === 'PIPE' || tag === 'BACKPIPE' || tag === 'COMPOSE' || tag === 'DOT' || tag === 'LOGIC' || tag === 'MATH' || tag === 'COMPARE' || tag === 'RELATION' || tag === 'SHIFT' || tag === 'IN' || tag === 'OF' || tag === 'TO' || tag === 'BY' || tag === 'FROM' || tag === 'EXTENDS' || tag === 'IMPLEMENTS')) {
+    if (tag === 'ASSIGN' && ((ref$ = val + '') !== '=' && ref$ !== ':=' && ref$ !== '+=') || tag === 'CREMENT' && val === '++' && (ref$ = this.tokens)[ref$.length - 2].spaced || (tag === '+-' || tag === 'PIPE' || tag === 'BACKPIPE' || tag === 'COMPOSE' || tag === 'DOT' || tag === 'LOGIC' || tag === 'MATH' || tag === 'COMPARE' || tag === 'RELATION' || tag === 'SHIFT' || tag === 'IN' || tag === 'OF' || tag === 'TO' || tag === 'BY' || tag === 'FROM' || tag === 'EXTENDS' || tag === 'IMPLEMENTS')) {
       return length;
     }
     if (delta) {
@@ -979,7 +979,9 @@ exports.dedent = function(debt){
 };
 exports.newline = function(){
   var ref$;
-  this.last[1] === '\n' || this.tokens.push(this.last = (ref$ = ['NEWLINE', '\n', this.line, this.column], ref$.spaced = true, ref$));
+  if (!(this.last[0] === 'NEWLINE' && this.last[1] === '\n')) {
+    this.tokens.push(this.last = (ref$ = ['NEWLINE', '\n', this.line, this.column], ref$.spaced = true, ref$));
+  }
 };
 exports.unline = function(){
   var ref$;
@@ -1326,30 +1328,59 @@ character = typeof JSON == 'undefined' || JSON === null
     }
   };
 function firstPass(tokens){
-  var prev, i, token, tag, val, line, column, next, ts, parens, i$, j;
+  var prev, i, token, tag, val, line, column, next, parens, i$, j, ts;
   prev = ['NEWLINE', '\n', 0];
   i = 0;
   while (token = tokens[++i]) {
     tag = token[0], val = token[1], line = token[2], column = token[3];
-    switch (false) {
-    case !(tag === 'ASSIGN' && in$(prev[1], LS_KEYWORDS) && tokens[i - 2][0] !== 'DOT'):
-      carp("cannot assign to reserved word '" + prev[1] + "'", line);
+    switch (tag) {
+    case 'ASSIGN':
+      if (in$(prev[1], LS_KEYWORDS) && tokens[i - 2][0] !== 'DOT') {
+        carp("cannot assign to reserved word '" + prev[1] + "'", line);
+      }
       break;
-    case !(tag === 'DOT' && prev[0] === ']' && tokens[i - 2][0] === '[' && tokens[i - 3][0] === 'DOT'):
-      tokens.splice(i - 2, 3);
-      tokens[i - 3][1] = '[]';
-      i -= 3;
+    case 'DOT':
+      switch (false) {
+      case !(prev[0] === ']' && tokens[i - 2][0] === '[' && tokens[i - 3][0] === 'DOT'):
+        tokens.splice(i - 2, 3);
+        tokens[i - 3][1] = '[]';
+        i -= 3;
+        break;
+      case !(prev[0] === '}' && tokens[i - 2][0] === '{' && tokens[i - 3][0] === 'DOT'):
+        tokens.splice(i - 2, 3);
+        tokens[i - 3][1] = '{}';
+        i -= 3;
+        break;
+      case !(val === '.' && token.spaced && prev.spaced):
+        tokens[i] = ['COMPOSE', '<<', line, column];
+        break;
+      default:
+        next = tokens[i + 1];
+        if (prev[0] === '(' && next[0] === ')') {
+          tokens[i][0] = 'BIOP';
+        } else if (prev[0] === '(') {
+          tokens.splice(i, 0, ['PARAM(', '(', line, column], [')PARAM', ')', line, column], ['->', '~>', line, column], ['ID', 'it', line, column]);
+        } else if (next[0] === ')') {
+          tokens.splice(i + 1, 0, ['[', '[', line, column], ['ID', 'it', line, column], [']', ']', line, column]);
+          parens = 1;
+          LOOP: for (i$ = i + 1; i$ >= 0; --i$) {
+            j = i$;
+            switch (tokens[j][0]) {
+            case ')':
+              ++parens;
+              break;
+            case '(':
+              if (--parens === 0) {
+                tokens.splice(j + 1, 0, ['PARAM(', '(', line, column], ['ID', 'it', line, column], [')PARAM', ')', line, column], ['->', '~>', line, column]);
+                break LOOP;
+              }
+            }
+          }
+        }
+      }
       break;
-    case !(tag === 'DOT' && prev[0] === '}' && tokens[i - 2][0] === '{' && tokens[i - 3][0] === 'DOT'):
-      tokens.splice(i - 2, 3);
-      tokens[i - 3][1] = '{}';
-      i -= 3;
-      break;
-    case !(val === '.' && token.spaced && prev.spaced):
-      tokens[i] = ['COMPOSE', '<<', line, column];
-      break;
-    case val !== '++':
-      if (!(next = tokens[i + 1])) {
+    case 'CREMENT':
+      if (!(val === '++' && (next = tokens[i + 1]))) {
         break;
       }
       ts = ['ID', 'LITERAL', 'STRNUM'];
@@ -1360,31 +1391,10 @@ function firstPass(tokens){
         tokens[i][0] = 'BIOP';
       }
       break;
-    case tag !== 'DOT':
-      next = tokens[i + 1];
-      if (prev[0] === '(' && next[0] === ')') {
-        tokens[i][0] = 'BIOP';
-      } else if (prev[0] === '(') {
-        tokens.splice(i, 0, ['PARAM(', '(', line, column], [')PARAM', ')', line, column], ['->', '~>', line, column], ['ID', 'it', line, column]);
-      } else if (next[0] === ')') {
-        tokens.splice(i + 1, 0, ['[', '[', line, column], ['ID', 'it', line, column], [']', ']', line, column]);
-        parens = 1;
-        LOOP: for (i$ = i + 1; i$ >= 0; --i$) {
-          j = i$;
-          switch (tokens[j][0]) {
-          case ')':
-            ++parens;
-            break;
-          case '(':
-            if (--parens === 0) {
-              tokens.splice(j + 1, 0, ['PARAM(', '(', line, column], ['ID', 'it', line, column], [')PARAM', ')', line, column], ['->', '~>', line, column]);
-              break LOOP;
-            }
-          }
-        }
+    case 'ID':
+      if (val !== 'async') {
+        break;
       }
-      break;
-    case !(tag === 'ID' && val === 'async'):
       next = tokens[i + 1];
       switch (next[0]) {
       case 'FUNCTION':

--- a/test/literal.ls
+++ b/test/literal.ls
@@ -119,6 +119,25 @@ compile-throws 'unterminated words' 5 '''
   <[
   '''
 
+# [LiveScript#739](https://github.com/gkz/LiveScript/issues/739)
+# For the below tests, it's important that there not be any extra whitespace
+# between the <[ ]> brackets. These tests guard against mistaking a WORDS token
+# for some other kind of token based on its value only.
+
+# Don't interpret WORDS:\n as a newline
+w = <[
+]>
+eq w.length, 0
+
+# And don't interpret WORDS:++ as concat
+w = <[++]>
+eq w.0, \++
+
+# And don't interpret WORDS:. as compose
+# (Note: the spacing and punctuation *outside* the <[ ]> brackets is also
+# significant in this test.)
+eq '' + <[.]> \.
+
 #### Implicit arrays
 o =
   atom:


### PR DESCRIPTION
This fixes three related issues around words literals (`<[ ]>`) being
mistaken for newlines or operators when their contents had the same
values as those other token types.

Fixes #739, closes #808.

---

All but the most trivial tweaks to the lexer make me nervous. Will hold for **two weeks**, merging on or after **April 16** if no feedback.