### PR TITLE
fix `in` in `case` guarding implicit `for..in`

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -283,7 +283,6 @@ exports.doID = function(code, index){
     }.call(this));
     break;
   case 'when':
-    this.fset('for', false);
     tag = 'CASE';
     // fallthrough
   case 'case':
@@ -609,7 +608,7 @@ exports.doSpace = function(code, lastIndex){
 };
 exports.doCase = function(){
   var ref$, ref1$;
-  this.seenFor = false;
+  this.fset('for', false);
   if (((ref$ = this.last[0]) === 'ASSIGN' || ref$ === '->' || ref$ === ':') || (this.last[0] === 'INDENT' && ((ref$ = (ref1$ = this.tokens)[ref1$.length - 2][0]) === 'ASSIGN' || ref$ === '->' || ref$ === ':'))) {
     this.token('SWITCH', 'switch');
     return this.token('CASE', 'case');

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -212,7 +212,6 @@ exports <<<
                   | last.0 is '(' => 'BIOP'
                   | otherwise     => 'WITH'
         case 'when'
-            @fset 'for' false
             tag = 'CASE'
             fallthrough
         case 'case'
@@ -467,9 +466,9 @@ exports <<<
         @last.spaced = true if input = SPACE.exec(code).0
         input.length
 
-    # Used from both do-literal (|) and do-ID (case): adds swtich if required
+    # Used from both do-literal (|) and do-ID (case): adds switch if required
     do-case: ->
-        @seen-for = false
+        @fset 'for' false
         if @last.0 in <[ ASSIGN -> : ]>
         or (@last.0 is 'INDENT' and @tokens[*-2].0 in <[ ASSIGN -> : ]>)
             @token 'SWITCH' 'switch'

--- a/test/loop.ls
+++ b/test/loop.ls
@@ -743,3 +743,16 @@ throws "Cannot read property 'length' of undefined" -> [0 for x in void]
 
 # [LiveScript#1035](https://github.com/gkz/LiveScript/issues/1035)
 for [1 2 3] then 1 else 0
+
+# [LiveScript#1039](https://github.com/gkz/LiveScript/issues/1039)
+arr = [3 2 1 0]
+x = for arr case .. in [1 2] => 1
+eq '1,1' x.join \,
+
+v = 1
+b = [1]
+x = for arr | v in b => 1
+eq '1,1,1,1' x.join \,
+
+x = [1 for arr case .. in [1 2]]
+eq '1,1' x.join \,


### PR DESCRIPTION
Fixes #1039. Will hold for **two weeks** because this is a lexer tweak, merging on or after **April 26** if there are no objections.