### PR TITLE
Fix for #1025

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1095,7 +1095,9 @@ exports.Chain = Chain = (function(superclass){
   };
   Chain.prototype.autoCompare = function(target){
     var test;
-    test = this.head;
+    if (!this.tails.length) {
+      test = this.head;
+    }
     switch (false) {
     case !(test instanceof Literal):
       return Binary('===', test, target[0]);

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -708,7 +708,7 @@ class exports.Chain extends Node
         this
 
     auto-compare: (target) ->
-        test = @head
+        test = @head unless @tails.length
         switch
         | test instanceof Literal
             Binary \===  test, target.0

--- a/test/operator.ls
+++ b/test/operator.ls
@@ -988,3 +988,15 @@ ok not (even or 1) 3
 ok ((.length > 4) or [1 2 3]) [1 2 3]
 
 eq 8 ((-> &0 + &1 is 5) and (**)) 2 3
+
+# [LiveScript#1025](https://github.com/gkz/LiveScript/issues/1025)
+# The placeholder logic from `match` is also applied here
+_ = -> -> false
+_.isString = -> typeof it == \string
+_.isNumber = -> typeof it == \number
+eq false (_.isString || _.isNumber) []
+eq false (_.isString || _!) []
+eq true  (_.isString || _.isNumber) 1
+
+# other examples of Chains with tails
+eq \bar ('foo'~slice || 'foobar'~slice) 3

--- a/test/switch.ls
+++ b/test/switch.ls
@@ -275,6 +275,23 @@ match 1, 3, 3
 | _            => ok 0
 
 
+# [LiveScript#1025](https://github.com/gkz/LiveScript/issues/1025)
+# Expressions starting from `_` were treated as placeholders in `match` cases
+_ = -> -> false
+_.isString = -> typeof it == \string
+match 1
+| _.isString   => ok 0
+| (_.isString) => ok 0
+| _!           => ok 0
+match \foo
+| _.isString   => ok 1
+
+# other examples of Chains with tails
+match \foo
+| 'barbaz'~starts-with => ok 0
+| 'foobar'~starts-with => ok 1
+| otherwise            => ok 0
+
 # [LiveScript#926](https://github.com/gkz/LiveScript/issues/926)
 # `match` wasn't binding `this` correctly in expression position
 o =


### PR DESCRIPTION
Fix for #1025.

This fixes placeholder handling in `match` and with calling logic operators, although the latter doesn't need placeholders at all.

I still think this calling logic operators feature is a miss. In terms of usability and intuition, I strongly prefer `match` over this, even though `match` isn't even documented.