### PR TITLE
Feature detection in the test environment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ browser/livescript-min.js:  browser/livescript.js
 package.json: package.json.ls
 	$(LSC) --compile package.json.ls
 
-.PHONY: build build-browser force full install dev-install test test-harmony coverage loc clean
+.PHONY: build build-browser force full install dev-install test coverage loc clean
 
 all: build
 
@@ -50,9 +50,6 @@ dev-install: package.json
 
 test: build
 	./scripts/test
-
-test-harmony: build
-	node --harmony ./scripts/test
 
 coverage: build
 	$(ISTANBUL) cover ./scripts/test

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "scripts": {
     "pretest": "make force && make force",
     "test": "make test",
-    "test-harmony": "make test-harmony",
     "posttest": "git checkout -- lib"
   },
   "preferGlobal": true,

--- a/package.json.ls
+++ b/package.json.ls
@@ -35,7 +35,6 @@ bin:
 scripts:
   pretest: 'make force && make force'
   test: 'make test'
-  'test-harmony': 'make test-harmony'
   posttest: 'git checkout -- lib'
 
 prefer-global: true

--- a/scripts/test
+++ b/scripts/test
@@ -21,6 +21,15 @@
     return color + text + reset;
   }
 
+  function testSyntax(code) {
+    try {
+      eval(code);
+    } catch (e) {
+      return false;
+    }
+    return true;
+  }
+
   var startTime = Date.now();
   var passedTests = 0;
   var failedTests = 0;
@@ -156,13 +165,13 @@
 
   var files = fs.readdirSync("test");
 
-  if (process.execArgv.indexOf("--harmony") < 0 && process.execArgv.indexOf("--harmony-generators") < 0) {
-    files.splice(files.indexOf("generators.ls"), 1);
+  if (testSyntax("(function* () {})")) {
+    console.log("Testing with generators.");
   } else {
-    console.log("Testing with harmony.");
+    files.splice(files.indexOf("generators.ls"), 1);
   }
-  var supportsAsync = parseInt(process.versions.node.split('.')[0]) >= 7;
-  if (supportsAsync) {
+
+  if (testSyntax("(async function () {})")) {
     console.log("Testing with async.");
   } else {
     files.splice(files.indexOf("async.ls"), 1);

--- a/scripts/test
+++ b/scripts/test
@@ -165,12 +165,6 @@
 
   var files = fs.readdirSync("test");
 
-  if (testSyntax("(function* () {})")) {
-    console.log("Testing with generators.");
-  } else {
-    files.splice(files.indexOf("generators.ls"), 1);
-  }
-
   if (testSyntax("(async function () {})")) {
     console.log("Testing with async.");
   } else {


### PR DESCRIPTION
Currently it was easy to miss testing generators, because of omitting the `--harmony` flag; even `make full` skipped testing generators.
This PR introduces detecting support for certain syntax oriented language features, before running tests.

This doesn't mean the tests will always run/pass on the older Node versions, as sometimes other new features are used, which are not syntax oriented, such as `String::startsWith`. The purpose of this PR is however to be able to always rely on the default `npm test` or `make full` and be sure, that having the newest runtime environment set up, all the tests will run.