### PR TITLE
Ensure using newer implementation of `Buffer.from`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -28,7 +28,7 @@ parser.lexer = {
     return '';
   }
 };
-bufferFrom = Buffer.from || function(it){
+bufferFrom = Buffer.alloc && Buffer.from || function(it){
   return new Buffer(it);
 };
 exports.VERSION = '1.5.0';

--- a/src/index.ls
+++ b/src/index.ls
@@ -26,7 +26,7 @@ parser <<<
             @tokens = it
         upcoming-input: -> ''
 
-bufferFrom = Buffer.from or -> new Buffer it
+bufferFrom = Buffer.alloc and Buffer.from or -> new Buffer it
 
 exports <<<
     VERSION: '1.5.0'


### PR DESCRIPTION
Prior to Node v5.10 (and v4.5) it's impossible to use `Buffer.from` for creating buffers from string.
Existence of `Buffer.alloc` implies the newer implementation of `Buffer.from` and possibility to use it with strings.