### PR TITLE
fix gkz/LiveScript#1038

### DIFF
--- a/lib/lexer.js
+++ b/lib/lexer.js
@@ -10,8 +10,8 @@ exports.rewrite = function(it){
   addImplicitIndentation(it);
   rewriteBlockless(it);
   addImplicitParentheses(it);
-  addImplicitBraces(it);
   expandLiterals(it);
+  addImplicitBraces(it);
   if (((ref$ = it[0]) != null ? ref$[0] : void 8) === 'NEWLINE') {
     it.shift();
   }

--- a/src/lexer.ls
+++ b/src/lexer.ls
@@ -31,8 +31,8 @@ exports <<<
         add-implicit-indentation it
         rewrite-blockless it
         add-implicit-parentheses it
-        add-implicit-braces it
         expand-literals it
+        add-implicit-braces it
         it.shift! if it.0?.0 is 'NEWLINE'
         it
 

--- a/test/literal.ls
+++ b/test/literal.ls
@@ -364,6 +364,17 @@ a = Array do
 eq 2, a.length
 eq 2, (Array 1: 2, 3).length
 
+# [LiveScript#1038](https://github.com/gkz/LiveScript/issues/1038):
+# More cases of not consuming shorthand properties.
+a = [a: 1 2 3]
+eq 3 a.length
+
+fn = (x, y, z) -> z
+eq 3 fn a: 1 2 3
+
+e = try LiveScript.compile 'x = a: 1 2' catch e
+eq "Parse error on line 1: Unexpected ','" e.message
+
 
 # With leading comments.
 obj =


### PR DESCRIPTION
Expressions such as `[a: 1 2 3]` should be equivalent to `[{a: 1}, 2, 3]` and not `[{a: 1, 2: 2, 3: 3}]`. Property shorthand, including atomic identifiers/literals as shorthand for key-value pairs with the atom as the key and value, should not work outside of braces.

---

This is technically a breaking change, though a relatively minor one. I'll hold this open for comments for **two weeks**, merging on or after **Oct 25** if there are no objections.