### PR TITLE
fix gkz/LiveScript#1096

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2740,7 +2740,7 @@ exports.Assign = Assign = (function(superclass){
       code.push(item, sep);
     }
     code.pop();
-    if (list.length < 2 || o.level < LEVEL_LIST) {
+    if ((o.level < LEVEL_OP && list.length < 2) || o.level < LEVEL_LIST) {
       return sn.apply(null, [this].concat(arrayFrom$(code)));
     } else {
       return sn.apply(null, [this, "("].concat(arrayFrom$(code), [")"]));

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1725,7 +1725,7 @@ class exports.Assign extends Node
         for item in list
             code.push item, sep
         code.pop!
-        if list.length < 2 or o.level < LEVEL_LIST then sn(this, ...code) else sn(this, "(", ...code, ")")
+        if (o.level < LEVEL_OP and list.length < 2) or o.level < LEVEL_LIST then sn(this, ...code) else sn(this, "(", ...code, ")")
 
     compileSplice: (o) ->
         [from-exp-node, from-exp] = Chain @left.from .cache-reference o

--- a/test/assignment.ls
+++ b/test/assignment.ls
@@ -404,6 +404,15 @@ o{d, e} &&*= d: 2, e: 3
 eq 0 o.d
 eq 3 o.e
 
+# https://github.com/gkz/LiveScript/issues/1096
+[{a}?] = [a: 1]
+eq 1 a
+a = null
+[{a}?] = []
+eq null a
+[[[a]?]?] = []
+eq null a
+
 
 ### Named Destructuring
 [b, c]:a = [0 1]

--- a/test/compilation.ls
+++ b/test/compilation.ls
@@ -394,3 +394,12 @@ ok compiled.starts-with 'var A;\n'
 
 compiled = LiveScript.compile 'a[b = c + d] **= e' {+bare,-header}
 ok compiled.starts-with 'var b;\n'
+
+
+# Don't wrap single destructuring statements in parentheses under these
+# specific conditions:
+#  * the destructuring is inside a conditional
+#  * the conditional is in an expression position
+#  * but the value of the conditional isn't needed
+compiled = LiveScript.compile 'a or if b then [@c] = d else 0' {+bare,-header}
+eq 'a || (b ? this.c = d[0] : 0);' compiled


### PR DESCRIPTION
The minor code optimization of omitting parentheses around a single
destructuring assignment is incorrect when the assignment is produced
inside a binary expression, as the binary operator interferes with the
parsing of the assignment's LHS in the generated JS.

This change restricts the optimization to cases where the current
precedence level is lower than that of binary operators. Since the
number of expressions includes a final expression that captures the
original RHS of the destructuring assignment if that value is needed,
and since the optimization is always applied to top-level and
parenthesis-level expressions by the second half of the if condition,
this change only has an effect on single-assignment destructuring
assignments that are direct children of a list or conditional
expression, where the value of the destructuring assignment expression
is not used (which rules out lists and most conditionals as well). #1096
illustrates one of the only ways such a circumstance is likely to arise
in natural code.

---

Okay, it's been a minute, but same deal as always: as a tweak to a minor optimization, I'll hold this open for comments for **one week**, merging on or after **Apr 23** if there are no objections.