### PR TITLE
fix gkz/LiveScript#1098

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2356,7 +2356,7 @@ exports.Binary = Binary = (function(superclass){
   Binary.prototype.compileExistence = function(o){
     var x;
     if (this['void'] || !o.level) {
-      x = Binary('&&', Existence(this.first, true), this.second);
+      x = Binary('&&', Existence(this.first, true), Parens(this.second.unwrap()));
       return (x['void'] = true, x).compileNode(o);
     }
     x = this.first.cache(o, true);
@@ -4409,7 +4409,7 @@ exports.If = If = (function(superclass){
     thn = this.then, els = this['else'] || Literal('void');
     this['void'] && (thn['void'] = els['void'] = true);
     if (!this['else'] && (this.cond || this['void'])) {
-      return Parens(Binary('&&', this['if'], thn)).compile(o);
+      return Parens(Binary('&&', this['if'], Parens(thn.unwrap()))).compile(o);
     }
     code = [sn(this, this['if'].compile(o, LEVEL_COND))];
     pad = els.isComplex() ? '\n' + (o.indent += TAB) : ' ';

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1456,7 +1456,7 @@ class exports.Binary extends Node
 
     compileExistence: (o) ->
         if @void or not o.level
-            x = Binary \&& Existence(@first, true), @second
+            x = Binary \&& Existence(@first, true), Parens @second.unwrap!
             return (x <<< {+void})compile-node o
         x = @first.cache o, true
         sn(this, If(Existence x.0; x.1)add-else(@second)compile-expression o)
@@ -2799,7 +2799,7 @@ class exports.If extends Node
         {then: thn, else: els or Literal \void} = this
         @void and thn.void = els.void = true
         if not @else and (@cond or @void)
-            return Parens Binary \&& @if, thn .compile o
+            return Parens Binary \&& @if, (Parens thn.unwrap!) .compile o
         code = [sn(this, @if.compile o, LEVEL_COND)]
         pad  = if els.is-complex! then \\n + o.indent += TAB else ' '
         code.push "#pad", sn(thn, "? "), (thn.compile o, LEVEL_LIST), "#pad", sn(els, ": "), (els.compile o, LEVEL_LIST)

--- a/test/existence.ls
+++ b/test/existence.ls
@@ -269,3 +269,11 @@ eq val.join(' '), '5 4 3 2 1'
 
 # Ensure `var that` is declared even if the tested variable exists
 eq 'var a, that, b;\na = 0;\nif ((that = a) != null) {\n  b = that;\n}', LiveScript.compile 'a = 0; b = that if a?' {+bare,-header}
+
+# `?` has lower precedence than `or`
+f = -> ok false
+a = 0 ? f! or f!
+eq 0 a
+
+# ... even when result is not used
+0 ? f! or f!

--- a/test/if.ls
+++ b/test/if.ls
@@ -168,3 +168,7 @@ else if true =>
   ok 0
 else
   ok 0
+
+# https://github.com/gkz/LiveScript/issues/1098
+f = -> ok false
+while (if false then f! or f!) then


### PR DESCRIPTION
Most of the time, the precedence difference between `&&` and `||`
doesn't need to be attended, because it's the same in LiveScript and
JavaScript. But when synthetic `&&` nodes are created, it's important to
ensure that the children of the node either must have had higher
precedence when parsed, are also synthetic and represent expressions
with higher precedence, or are wrapped in `Parens`. The reported bug,
and a similar issue with the binary `?` operator, are the consequences
if not.

---

As a simple bug fix, I will hold this PR open for **one week**, merging on or after **Apr 27** if there are no comments, unless @gkz gets to it first again! :grin: