### PR TITLE
Fix rewrite-shorthand regressions

### DIFF
--- a/lib/ast.js
+++ b/lib/ast.js
@@ -1432,17 +1432,18 @@ exports.Chain = Chain = (function(superclass){
     }
   };
   Chain.prototype.rewriteShorthand = function(o, assign){
-    var that, i$, ref$, len$, i, item;
+    var that, lastI, i$, ref$, len$, i, item;
     if (that = this.unfoldSoak(o)) {
       return that.rewriteShorthand(o, assign) || that;
     }
     if (that = this.head.rewriteShorthand(o)) {
       this.head = that;
     }
+    lastI = this.tails.length - 1;
     for (i$ = 0, len$ = (ref$ = this.tails).length; i$ < len$; ++i$) {
       i = i$;
       item = ref$[i$];
-      if (that = item.rewriteShorthand(o, assign)) {
+      if (that = item.rewriteShorthand(o, assign && i === lastI)) {
         this.tails[i] = that;
       }
     }

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2241,6 +2241,10 @@ exports.Binary = Binary = (function(superclass){
       return this;
     }
   };
+  Binary.prototype.assigns = function(){
+    var ref$;
+    return (ref$ = this.getDefault()) != null ? ref$.first.assigns() : void 8;
+  };
   Binary.prototype.xorChildren = function(test){
     var ref$, first;
     if (!(!(first = test(this.first)) !== !(ref$ = test(this.second)) && (first || ref$))) {
@@ -3982,13 +3986,10 @@ exports.For = For = (function(superclass){
     return ((this.kind || []).concat(this.index)).join(' ');
   };
   For.prototype.addBody = function(body){
-    var ref$, that, assignments, x$, assigned, name, ref1$;
+    var ref$, assignments, x$, that, assigned, name;
     if (this['let']) {
       if (ref$ = this.ref, delete this.ref, ref$) {
         this.item = Literal('..');
-      }
-      if (that = (ref$ = this.item) != null ? ref$.rewriteShorthand() : void 8) {
-        this.item = that;
       }
       assignments = (x$ = [], (that = this.index) && x$.push(Assign(Var(that), Literal('index$$'))), (that = this.item) && x$.push(Assign(that, Literal('item$$'))), x$);
       body = Block(this.guard
@@ -4004,7 +4005,7 @@ exports.For = For = (function(superclass){
             }
           }
           return results$;
-        }()), assignments.concat([If((ref1$ = this.guard, delete this.guard, ref1$), Call['let'](assigned, body))]))
+        }()), assignments.concat([If((ref$ = this.guard, delete this.guard, ref$), Call['let'](assigned, body))]))
         : Call['let'](assignments, body));
     }
     superclass.prototype.addBody.call(this, body);

--- a/lib/ast.js
+++ b/lib/ast.js
@@ -2549,6 +2549,18 @@ exports.Binary = Binary = (function(superclass){
     right = Chain(this.second).cacheReference(o);
     return sn(this, Binary('&&', Binary('!==', Unary('!', left[0]), Unary('!', right[0])), Parens(Binary('||', left[1], right[1]))).compile(o));
   };
+  Binary.prototype.rewriteShorthand = function(o, assign){
+    var that;
+    if (this.partial) {
+      return superclass.prototype.rewriteShorthand.apply(this, arguments);
+    }
+    if (that = this.first.rewriteShorthand(o, assign)) {
+      this.first = that;
+    }
+    if (that = this.second.rewriteShorthand(o)) {
+      this.second = that;
+    }
+  };
   return Binary;
 }(Node));
 exports.Assign = Assign = (function(superclass){

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -932,8 +932,9 @@ class exports.Chain extends Node
     rewrite-shorthand: (o, assign) ->
         return that.rewrite-shorthand o, assign or that if @unfold-soak o
         @head = that if @head.rewrite-shorthand o
+        last-i = @tails.length - 1
         for item, i in @tails
-            @tails[i] = that if item.rewrite-shorthand o, assign
+            @tails[i] = that if item.rewrite-shorthand(o, assign && i is last-i)
         @expand-slice o, assign
         @unwrap!
 

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1589,6 +1589,11 @@ class exports.Binary extends Node
         sn(this, (Binary \&& (Binary \!== (Unary \! left.0), (Unary \! right.0))
              , (Parens Binary \|| left.1, right.1) .compile o))
 
+    rewrite-shorthand: (o, assign) !->
+        return super ... if @partial
+        @first = that if @first.rewrite-shorthand o, assign
+        @second = that if @second.rewrite-shorthand o
+
 #### Assign
 # Assignment to a variable/property.
 class exports.Assign extends Node

--- a/src/ast.ls
+++ b/src/ast.ls
@@ -1398,6 +1398,8 @@ class exports.Binary extends Node
 
     get-default: -> switch @op | \? \|| \&& => this
 
+    assigns: -> @get-default!?first.assigns!
+
     xor-children: (test) ->
         return false unless (first = test @first) xor test @second
         return if first then [@first, @second] else [@second, @first]
@@ -2536,7 +2538,6 @@ class exports.For extends While
     add-body: (body) ->
         if @let
             @item = Literal \.. if delete @ref
-            @item = that if @item?rewrite-shorthand!
             assignments = with []
                 ..push Assign Var(that), Literal \index$$ if @index
                 ..push Assign that,      Literal \item$$ if @item

--- a/test/assignment.ls
+++ b/test/assignment.ls
@@ -390,6 +390,11 @@ new
   @{a &&= 2, b ||= 3} = {a: 99}
   eq @a * @b, 6
 
+  i = 0
+  f = -> ++i
+  [@a or {(f!)}] = [false]
+  eq @a.1, 1
+
 compile-throws 'invalid assign' 1 'o{...(a) ? b} = c'
 
 ### Compound/Conditional Destructuring

--- a/test/chaining.ls
+++ b/test/chaining.ls
@@ -291,3 +291,9 @@ eq true delete! a?{x}[\x]y
 eq void b.x.y
 a = [4 3]
 eq '4,3,2' "#{a?[0 1] <<< {2}}"
+
+# Assigning through computed properties in slices
+p = -> \q
+o = q: r: 1
+o{(p!)}q.r = 1
+eq 1 o.q.r

--- a/test/loop.ls
+++ b/test/loop.ls
@@ -731,6 +731,22 @@ expected =
   * b: \default c: {} e: 3
 deep-equal expected, r
 
+# Unreported for-let regression
+arr =
+  * x: 6 y: 7
+  * x: 8 y: 9
+o = x: \x y: \y
+i = 0
+f = -> i++; o
+fns = for let {(f!x), (f!y)} in arr
+  t = o{x, y}
+  o.x = \x
+  o.y = \y
+  -> t
+r = for f in fns then f!
+deep-equal arr, r
+eq 4 i
+
 # Certain literals could result in illegal JavaScript if not carefully
 # handled. These are all nonsensical use cases and could just as easily
 # be LiveScript syntax errors. The thing to avoid is for them to be JavaScript


### PR DESCRIPTION
As a continuation of the mea culpas in #1103, here are some more things that broke with my rewrite-shorthand refactoring.

This is a simpler pack of fixes than the last one, so I'm giving it **two weeks**, to be merged on or after **July 14** if there are no comments.

I'd also like to attempt a point release after this and possibly #1104 are merged, since there are now a substantial number of regressions associated with the previous release which will be fixed.