### PR TITLE
Fixing test script for windows

### DIFF
--- a/test/cli.ls
+++ b/test/cli.ls
@@ -49,16 +49,21 @@ command-eq '-cp test/data/data.json.ls', [json-content ]
 command-eq '-cp --json test/data/data.ls', [json-content]
 
 # json to files
+normed-json = (ext = '') ->
+    (normalize 'test/data/data') ++ "#ext.ls => " ++ (normalize 'test/data/data.json')
+
 do
     # implicit json
-    <- command-eq '-c --debug test/data/data.json.ls', ['test/data/data.json.ls => test/data/data.json']
+    #<- command-eq '-c --debug test/data/data.json.ls', ['test/data/data.json.ls => test/data/data.json']
+    <- command-eq '-c --debug test/data/data.json.ls', [normed-json '.json']
     try
         ok file-exists 'test/data/data.json'
         eq json-content + '\n', file-read 'test/data/data.json'
     finally file-delete 'test/data/data.json'
 
     # explicit json
-    <- command-eq '-cj --debug test/data/data.ls', ['test/data/data.ls => test/data/data.json']
+    #<- command-eq '-cj --debug test/data/data.ls', ['test/data/data.ls => test/data/data.json']
+    <- command-eq '-cj --debug test/data/data.ls', [normed-json!]
     try
         ok file-exists 'test/data/data.json'
         eq json-content + '\n', file-read 'test/data/data.json'
@@ -86,7 +91,7 @@ command-eq '-c --debug --map linked test/data/empty.ls', [
 # gkz/LiveScript#953
 command-eq '-m embedded test/data/runtime-error.ls', [
     'Failed at: test/data/runtime-error.ls'
-    /ReferenceError: doesNotExist is not defined\n    at Object\.<anonymous> \(.*\/test\/data\/runtime-error\.ls:2:17\).*/
+    /ReferenceError: doesNotExist is not defined[\r\n]{1,2}    at Object\.<anonymous> \([\.\*\\\/\:a-zA-Z]*runtime-error\.ls:2:17\).*/
 ]
 
 # eval+compile


### PR DESCRIPTION
The issue:

When running the test script in `scripts/test` on Windows some tests failed because of some paths. The two paths are:

- for `runtime-error.ls`, there is a carriage  return (`\r`) before the `\n`, and the path is absolute with `\` (in th script it's `.*/test/data/runtime-error.ls`)
- for `data.json.ls`, the output of `lsc -c --debug test/data/data.json.ls` used `\` on windows
- same for `data.ls`

Fix:

All the regex are in `test/cli.ls`.

- The `runtime-error.ls` regex is fixed by adding a check on the new line mess (`[\r\n]{1,2}`) and the absolute path is abstracted. The code still checks if it's `runtime-error.ls` that is throwing the error, and if it's line 2, char 17.
- For `data.json.ls` and `data.ls` the path is now normalized.

NOTE: I haven't any linux on hand to check if the new regex and normalize will fail on it. If someone can check on it, it would be great. I'll try tomorrow to run it on linux, but another pair of eyes is better than one ;-)